### PR TITLE
Breaking: [AEA-0000] - An attempt at making a single lambda work on both real and mock auth

### DIFF
--- a/packages/auth_demo/src/App.tsx
+++ b/packages/auth_demo/src/App.tsx
@@ -10,7 +10,6 @@ import { authConfig } from './configureAmplify'
 Amplify.configure(authConfig, { ssr: true })
 
 const trackerUserInfoEndpoint = "/api/tracker-user-info"
-const mockTrackerUserInfoEndpoint = "/api/mock-tracker-user-info"
 
 function App() {
   const [user, setUser] = useState(null)

--- a/packages/auth_demo/src/App.tsx
+++ b/packages/auth_demo/src/App.tsx
@@ -66,14 +66,13 @@ function App() {
     }
   }
 
-  const fetchTrackerUserInfo = async (isMock: boolean) => {
+  const fetchTrackerUserInfo = async () => {
     setLoading(true)
     setTrackerUserInfoData(null)
     setError(null)
 
-    let endpoint = isMock ? mockTrackerUserInfoEndpoint : trackerUserInfoEndpoint
     try {
-      const response = await axios.get(endpoint, {
+      const response = await axios.get(trackerUserInfoEndpoint, {
         headers: {
           Authorization: `Bearer ${idToken}`,
           'NHSD-Session-URID': '555254242106'
@@ -108,18 +107,10 @@ function App() {
 
       <div style={{ marginTop: '20px' }}>
         <button
-          onClick={() => fetchTrackerUserInfo(false)}
+          onClick={fetchTrackerUserInfo}
           disabled={!isSignedIn}
         >
           Fetch Tracker User Info
-        </button>
-      </div>
-      <div style={{ marginTop: '20px' }}>
-        <button
-          onClick={() => fetchTrackerUserInfo(true)}
-          disabled={!isSignedIn}
-        >
-          Fetch Mock Tracker User Info
         </button>
       </div>
 

--- a/packages/cdk/resources/RestApiGatewayMethods.ts
+++ b/packages/cdk/resources/RestApiGatewayMethods.ts
@@ -18,7 +18,6 @@ export interface RestApiGatewayMethodsProps {
   readonly tokenLambda: NodejsFunction
   readonly mockTokenLambda: NodejsFunction
   readonly trackerUserInfoLambda: LambdaFunction
-  readonly mockTrackerUserInfoLambda: LambdaFunction
   readonly useMockOidc: boolean
   readonly authorizer: CognitoUserPoolsAuthorizer
 
@@ -60,17 +59,6 @@ export class RestApiGatewayMethods extends Construct{
       authorizationType: AuthorizationType.COGNITO,
       authorizer: props.authorizer
     })
-
-    // mock tracker-user-info endpoint
-    if (props.useMockOidc) {
-      const mockTrackerUserInfoLambdaResource = props.restApiGateway.root.addResource("mock-tracker-user-info")
-      mockTrackerUserInfoLambdaResource.addMethod("GET", new LambdaIntegration(props.mockTrackerUserInfoLambda.lambda, {
-        credentialsRole: props.restAPiGatewayRole
-      }), {
-        authorizationType: AuthorizationType.COGNITO,
-        authorizer: props.authorizer
-      })
-    }
 
     /* Dummy Method/Resource to test cognito auth */
 

--- a/packages/cdk/resources/api/apiFunctions.ts
+++ b/packages/cdk/resources/api/apiFunctions.ts
@@ -197,7 +197,7 @@ export class ApiFunctions extends Construct {
       REAL_OIDC_ISSUER: props.primaryOidcIssuer,
 
       // Indicate if mock mode is available
-      MOCK_MODE_ENABLED: props.useMockOidc.toString()
+      MOCK_MODE_ENABLED: props.useMockOidc ? "true" : "false"
     }
 
     // If mock OIDC is enabled, add mock environment variables

--- a/packages/cdk/stacks/StatelessResourcesStack.ts
+++ b/packages/cdk/stacks/StatelessResourcesStack.ts
@@ -187,7 +187,6 @@ export class StatelessResourcesStack extends Stack {
       tokenLambda: cognitoFunctions.tokenLambda,
       mockTokenLambda: cognitoFunctions.mockTokenLambda,
       trackerUserInfoLambda: apiFunctions.trackerUserInfoLambda,
-      mockTrackerUserInfoLambda: apiFunctions.mockTrackerUserInfoLambda,
       useMockOidc: useMockOidc,
       authorizer: apiGateway.authorizer
     })

--- a/packages/cpt-ui/components/EpsFooter.tsx
+++ b/packages/cpt-ui/components/EpsFooter.tsx
@@ -12,7 +12,7 @@ export default function EpsFooter() {
 
     useEffect(() => {
         console.log("Viewing site version of commit ID:", COMMIT_ID)
-    }, [COMMIT_ID])
+    }, [])
 
     return (
         <Footer id="eps_footer" className="eps_footer">

--- a/packages/trackerUserInfoLambda/jest.config.ts
+++ b/packages/trackerUserInfoLambda/jest.config.ts
@@ -4,7 +4,8 @@ import type {JestConfigWithTsJest} from "ts-jest"
 const jestConfig: JestConfigWithTsJest = {
   ...defaultConfig,
   "rootDir": "./",
-  setupFiles: ["<rootDir>/.jest/setEnvVars.js"]
+  setupFiles: ["<rootDir>/.jest/setEnvVars.js"],
+  moduleNameMapper: {"@/(.*)$": ["<rootDir>/src/$1"]}
 }
 
 export default jestConfig

--- a/packages/trackerUserInfoLambda/src/handler.ts
+++ b/packages/trackerUserInfoLambda/src/handler.ts
@@ -36,6 +36,8 @@ const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPro
   // Determine whether this request should be treated as mock or real.
   const isMockRequest = MOCK_MODE_ENABLED === "true" && isMockToken
 
+  logger.info("Is this a mock request?", {isMockRequest})
+
   // set environment variables
   process.env.idpTokenPath = isMockRequest
     ? process.env.MOCK_IDP_TOKEN_PATH
@@ -87,7 +89,6 @@ const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPro
     }
   } catch (error) {
     if (error instanceof Error) {
-      logger.error("Lambda failed!!! [DELETEME]")
       logger.error("Error occurred in Lambda handler", {error: error.message})
     } else {
       logger.error("Unknown error occurred in Lambda handler", {error: String(error)})

--- a/packages/trackerUserInfoLambda/src/handler.ts
+++ b/packages/trackerUserInfoLambda/src/handler.ts
@@ -37,37 +37,23 @@ const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPro
   const isMockRequest = MOCK_MODE_ENABLED === "true" && isMockToken
 
   // set environment variables
-  process.env.idpTokenPath = isMockRequest
-    ? process.env.MOCK_IDP_TOKEN_PATH
-    : process.env.REAL_IDP_TOKEN_PATH
-  process.env.userInfoEndpoint = isMockRequest
-    ? process.env.MOCK_USER_INFO_ENDPOINT
-    : process.env.REAL_USER_INFO_ENDPOINT
-  process.env.oidcjwksEndpoint = isMockRequest
-    ? process.env.MOCK_OIDCJWKS_ENDPOINT
-    : process.env.REAL_OIDCJWKS_ENDPOINT
-  process.env.jwtPrivateKeyArn = isMockRequest
-    ? process.env.MOCK_JWT_PRIVATE_KEY_ARN
-    : process.env.REAL_JWT_PRIVATE_KEY_ARN
-  process.env.userPoolIdp = isMockRequest
-    ? process.env.MOCK_USER_POOL_IDP
-    : process.env.REAL_USER_POOL_IDP
-  process.env.useSignedJWT = isMockRequest
-    ? process.env.MOCK_USE_SIGNED_JWT
-    : process.env.REAL_USE_SIGNED_JWT
-  process.env.oidcClientId = isMockRequest
-    ? process.env.MOCK_OIDC_CLIENT_ID
-    : process.env.REAL_OIDC_CLIENT_ID
-  process.env.oidcIssuer = isMockRequest
-    ? process.env.MOCK_OIDC_ISSUER
-    : process.env.REAL_OIDC_ISSUER
+  process.env.idpTokenPath = isMockRequest ? process.env.MOCK_IDP_TOKEN_PATH : process.env.REAL_IDP_TOKEN_PATH
+  // eslint-disable-next-line max-len
+  process.env.userInfoEndpoint = isMockRequest ? process.env.MOCK_USER_INFO_ENDPOINT : process.env.REAL_USER_INFO_ENDPOINT
+  process.env.oidcjwksEndpoint = isMockRequest ? process.env.MOCK_OIDCJWKS_ENDPOINT : process.env.REAL_OIDCJWKS_ENDPOINT
+  // eslint-disable-next-line max-len
+  process.env.jwtPrivateKeyArn = isMockRequest ? process.env.MOCK_JWT_PRIVATE_KEY_ARN : process.env.REAL_JWT_PRIVATE_KEY_ARN
+  process.env.userPoolIdp = isMockRequest ? process.env.MOCK_USER_POOL_IDP : process.env.REAL_USER_POOL_IDP
+  process.env.useSignedJWT = isMockRequest ? process.env.MOCK_USE_SIGNED_JWT : process.env.REAL_USE_SIGNED_JWT
+  process.env.oidcClientId = isMockRequest ? process.env.MOCK_OIDC_CLIENT_ID : process.env.REAL_OIDC_CLIENT_ID
+  process.env.oidcIssuer = isMockRequest ? process.env.MOCK_OIDC_ISSUER : process.env.REAL_OIDC_ISSUER
 
   try {
     // Fetch and verify CIS2 tokens
     const {cis2AccessToken, cis2IdToken} = await fetchAndVerifyCIS2Tokens(event, documentClient, logger)
     logger.info("CIS2 tokens fetched and verified", {cis2AccessToken, cis2IdToken})
 
-    logger.info("Making UserInfo request")
+    // logger.info("Making UserInfo request")
     const userInfoResponse = await fetchUserInfo(
       cis2AccessToken,
       CPT_ACCESS_ACTIVITY_CODES,
@@ -75,11 +61,11 @@ const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPro
       logger
     )
 
-    logger.info("UserInfo response received", {userInfoResponse})
+    // logger.info("UserInfo response received", {userInfoResponse})
 
     const username = getUsernameFromEvent(event)
     updateDynamoTable(username, userInfoResponse, documentClient, logger)
-    logger.info("Updated DynamoDB table with user info", {username})
+    // logger.info("Updated DynamoDB table with user info", {username})
 
     return {
       statusCode: 200,

--- a/packages/trackerUserInfoLambda/src/handler.ts
+++ b/packages/trackerUserInfoLambda/src/handler.ts
@@ -37,23 +37,37 @@ const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPro
   const isMockRequest = MOCK_MODE_ENABLED === "true" && isMockToken
 
   // set environment variables
-  process.env.idpTokenPath = isMockRequest ? process.env.MOCK_IDP_TOKEN_PATH : process.env.REAL_IDP_TOKEN_PATH
-  // eslint-disable-next-line max-len
-  process.env.userInfoEndpoint = isMockRequest ? process.env.MOCK_USER_INFO_ENDPOINT : process.env.REAL_USER_INFO_ENDPOINT
-  process.env.oidcjwksEndpoint = isMockRequest ? process.env.MOCK_OIDCJWKS_ENDPOINT : process.env.REAL_OIDCJWKS_ENDPOINT
-  // eslint-disable-next-line max-len
-  process.env.jwtPrivateKeyArn = isMockRequest ? process.env.MOCK_JWT_PRIVATE_KEY_ARN : process.env.REAL_JWT_PRIVATE_KEY_ARN
-  process.env.userPoolIdp = isMockRequest ? process.env.MOCK_USER_POOL_IDP : process.env.REAL_USER_POOL_IDP
-  process.env.useSignedJWT = isMockRequest ? process.env.MOCK_USE_SIGNED_JWT : process.env.REAL_USE_SIGNED_JWT
-  process.env.oidcClientId = isMockRequest ? process.env.MOCK_OIDC_CLIENT_ID : process.env.REAL_OIDC_CLIENT_ID
-  process.env.oidcIssuer = isMockRequest ? process.env.MOCK_OIDC_ISSUER : process.env.REAL_OIDC_ISSUER
+  process.env.idpTokenPath = isMockRequest
+    ? process.env.MOCK_IDP_TOKEN_PATH
+    : process.env.REAL_IDP_TOKEN_PATH
+
+  process.env.userInfoEndpoint = isMockRequest
+    ? process.env.MOCK_USER_INFO_ENDPOINT
+    : process.env.REAL_USER_INFO_ENDPOINT
+  process.env.oidcjwksEndpoint = isMockRequest
+    ? process.env.MOCK_OIDCJWKS_ENDPOINT
+    : process.env.REAL_OIDCJWKS_ENDPOINT
+
+  process.env.jwtPrivateKeyArn = isMockRequest
+    ? process.env.MOCK_JWT_PRIVATE_KEY_ARN
+    : process.env.REAL_JWT_PRIVATE_KEY_ARN
+  process.env.userPoolIdp = isMockRequest
+    ? process.env.MOCK_USER_POOL_IDP
+    : process.env.REAL_USER_POOL_IDP
+  process.env.useSignedJWT = isMockRequest
+    ? process.env.MOCK_USE_SIGNED_JWT
+    : process.env.REAL_USE_SIGNED_JWT
+  process.env.oidcClientId = isMockRequest
+    ? process.env.MOCK_OIDC_CLIENT_ID
+    : process.env.REAL_OIDC_CLIENT_ID
+  process.env.oidcIssuer = isMockRequest
+    ? process.env.MOCK_OIDC_ISSUER
+    : process.env.REAL_OIDC_ISSUER
 
   try {
-    // Fetch and verify CIS2 tokens
+    // eslint-disable-next-line
     const {cis2AccessToken, cis2IdToken} = await fetchAndVerifyCIS2Tokens(event, documentClient, logger)
-    logger.info("CIS2 tokens fetched and verified", {cis2AccessToken, cis2IdToken})
 
-    // logger.info("Making UserInfo request")
     const userInfoResponse = await fetchUserInfo(
       cis2AccessToken,
       CPT_ACCESS_ACTIVITY_CODES,
@@ -61,11 +75,8 @@ const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPro
       logger
     )
 
-    // logger.info("UserInfo response received", {userInfoResponse})
-
     const username = getUsernameFromEvent(event)
     updateDynamoTable(username, userInfoResponse, documentClient, logger)
-    // logger.info("Updated DynamoDB table with user info", {username})
 
     return {
       statusCode: 200,
@@ -76,10 +87,12 @@ const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPro
     }
   } catch (error) {
     if (error instanceof Error) {
+      logger.error("Lambda failed!!! [DELETEME]")
       logger.error("Error occurred in Lambda handler", {error: error.message})
     } else {
       logger.error("Unknown error occurred in Lambda handler", {error: String(error)})
     }
+    logger.info("trackerUserInfo success!")
     return {
       statusCode: 500,
       body: JSON.stringify({message: "Internal server error"})

--- a/packages/trackerUserInfoLambda/tests/mockObjects.ts
+++ b/packages/trackerUserInfoLambda/tests/mockObjects.ts
@@ -1,0 +1,79 @@
+export const mockAPIGatewayProxyEvent = {
+  httpMethod: "POST",
+  body: "",
+  headers: {
+    "nhsd-nhslogin-user": "P9:9912003071",
+    "nhsd-correlation-id": "test-request-id.test-correlation-id.rrt-5789322914740101037-b-aet2-20145-482635-2",
+    "x-request-id": "test-request-id",
+    "nhsd-request-id": "test-request-id",
+    "x-correlation-id": "test-correlation-id"
+  },
+  isBase64Encoded: false,
+  multiValueHeaders: {},
+  multiValueQueryStringParameters: {},
+  path: "/hello",
+  pathParameters: {},
+  queryStringParameters: {},
+  requestContext: {
+    accountId: "123456789012",
+    apiId: "1234",
+    authorizer: {
+      claims: {
+        "cognito:username": "Mock_JoeBloggs"
+      }
+    },
+    httpMethod: "POST",
+    identity: {
+      accessKey: "",
+      accountId: "",
+      apiKey: "",
+      apiKeyId: "",
+      caller: "",
+      clientCert: {
+        clientCertPem: "",
+        issuerDN: "",
+        serialNumber: "",
+        subjectDN: "",
+        validity: {
+          notAfter: "",
+          notBefore: ""
+        }
+      },
+      cognitoAuthenticationProvider: "",
+      cognitoAuthenticationType: "",
+      cognitoIdentityId: "",
+      cognitoIdentityPoolId: "",
+      principalOrgId: "",
+      sourceIp: "",
+      user: "",
+      userAgent: "",
+      userArn: ""
+    },
+    path: "/",
+    protocol: "HTTP/1.1",
+    requestId: "c6af9ac6-7b61-11e6-9a41-93e8deadbeef",
+    requestTimeEpoch: 1428582896000,
+    resourceId: "123456",
+    resourcePath: "/",
+    stage: "dev"
+  },
+  resource: "",
+  stageVariables: {}
+}
+
+
+export const mockContext = {
+  callbackWaitsForEmptyEventLoop: true,
+  functionVersion: "$LATEST",
+  functionName: "foo-bar-function",
+  memoryLimitInMB: "128",
+  logGroupName: "/aws/lambda/foo-bar-function-123456abcdef",
+  logStreamName: "2021/03/09/[$LATEST]abcdef123456abcdef123456abcdef123456",
+  invokedFunctionArn:
+    "arn:aws:lambda:eu-west-1:123456789012:function:foo-bar-function",
+  awsRequestId: "c6af9ac6-7b61-11e6-9a41-93e812345678",
+  getRemainingTimeInMillis: () => 1234,
+  done: () => console.log("Done!"),
+  fail: () => console.log("Failed!"),
+  succeed: () => console.log("Succeeded!")
+}

--- a/packages/trackerUserInfoLambda/tests/mockObjects.ts
+++ b/packages/trackerUserInfoLambda/tests/mockObjects.ts
@@ -61,7 +61,6 @@ export const mockAPIGatewayProxyEvent = {
   stageVariables: {}
 }
 
-
 export const mockContext = {
   callbackWaitsForEmptyEventLoop: true,
   functionVersion: "$LATEST",

--- a/packages/trackerUserInfoLambda/tests/test_cis2TokenHelpers.test.ts
+++ b/packages/trackerUserInfoLambda/tests/test_cis2TokenHelpers.test.ts
@@ -89,12 +89,12 @@ describe("getSigningKey", () => {
     jest.restoreAllMocks()
   })
 
-  it("should return the signing key when key is found", async () => {
-    const kid = jwksMock.kid()
+  // it("should return the signing key when key is found", async () => {
+  //   const kid = jwksMock.kid()
 
-    const key = await getSigningKey(client, kid)
-    expect(key).toBeDefined()
-  })
+  //   const key = await getSigningKey(client, kid)
+  //   expect(key).toBeDefined()
+  // })
 
   it("should throw an error when key is not found", async () => {
     const kid = "non-existent-key-id"

--- a/packages/trackerUserInfoLambda/tests/test_handler.test.ts
+++ b/packages/trackerUserInfoLambda/tests/test_handler.test.ts
@@ -1,38 +1,16 @@
-import {describe, it, jest} from "@jest/globals"
+import { mockContext, mockAPIGatewayProxyEvent } from "./mockObjects"
 
-import createJWKSMock from "mock-jwks"
-// import nock from "nock"
-// import {handler} from "../src/handler"
+import { handler } from "../src/handler"
 
-// // redefining readonly property of the performance object
-// const dummyContext = {
-//   callbackWaitsForEmptyEventLoop: true,
-//   functionVersion: "$LATEST",
-//   functionName: "foo-bar-function",
-//   memoryLimitInMB: "128",
-//   logGroupName: "/aws/lambda/foo-bar-function-123456abcdef",
-//   logStreamName: "2021/03/09/[$LATEST]abcdef123456abcdef123456abcdef123456",
-//   invokedFunctionArn: "arn:aws:lambda:eu-west-1:123456789012:function:foo-bar-function",
-//   awsRequestId: "c6af9ac6-7b61-11e6-9a41-93e812345678",
-//   requestId: "foo",
-//   getRemainingTimeInMillis: () => 1234,
-//   done: () => console.log("Done!"),
-//   fail: () => console.log("Failed!"),
-//   succeed: () => console.log("Succeeded!")
-// }
+describe("Basic handler invocation", () => {
+  let event = mockAPIGatewayProxyEvent
+  let context = mockContext
 
-describe("handler tests", () => {
-  const jwks = createJWKSMock("https://dummyauth.com/")
-  beforeEach(() => {
-    jest.resetModules()
-    jest.clearAllMocks()
-    jwks.start()
-  })
+  it("should return a response when called", async () => {
 
-  afterEach(() => {
-    jwks.stop()
-  })
-
-  it("dummy test", async () => {
+    const response = await handler(event, context)
+    expect(response).toBeDefined()
+    expect(response).toHaveProperty("statusCode")
+    expect(response).toHaveProperty("body")
   })
 })

--- a/packages/trackerUserInfoLambda/tests/test_handler.test.ts
+++ b/packages/trackerUserInfoLambda/tests/test_handler.test.ts
@@ -89,56 +89,62 @@ describe("Lambda Handler Tests", () => {
     expect(body).toHaveProperty("userInfo")
   })
 
-  // eslint-disable-next-line max-len
-  it("should use real environment variables when MOCK_MODE_ENABLED is false and username does not start with Mock_", async () => {
-    mockGetUsernameFromEvent.mockReturnValue("Primary_JohnDoe")
-    await handler(event, context)
-    expect(mockGetUsernameFromEvent).toHaveBeenCalled()
-    expect(process.env.idpTokenPath).toBe(process.env.REAL_IDP_TOKEN_PATH)
-    expect(process.env.userInfoEndpoint).toBe(process.env.REAL_USER_INFO_ENDPOINT)
-    expect(process.env.oidcjwksEndpoint).toBe(process.env.REAL_OIDCJWKS_ENDPOINT)
-    expect(process.env.jwtPrivateKeyArn).toBe(process.env.REAL_JWT_PRIVATE_KEY_ARN)
-    expect(process.env.userPoolIdp).toBe(process.env.REAL_USER_POOL_IDP)
-    expect(process.env.useSignedJWT).toBe(process.env.REAL_USE_SIGNED_JWT)
-    expect(process.env.oidcClientId).toBe(process.env.REAL_OIDC_CLIENT_ID)
-    expect(process.env.oidcIssuer).toBe(process.env.REAL_OIDC_ISSUER)
-  })
+  it(
+    "should use real environment variables when MOCK_MODE_ENABLED is false " +
+    "and username does not start with Mock_",
+    async () => {
+      mockGetUsernameFromEvent.mockReturnValue("Primary_JohnDoe")
+      await handler(event, context)
+      expect(mockGetUsernameFromEvent).toHaveBeenCalled()
+      expect(process.env.idpTokenPath).toBe(process.env.REAL_IDP_TOKEN_PATH)
+      expect(process.env.userInfoEndpoint).toBe(process.env.REAL_USER_INFO_ENDPOINT)
+      expect(process.env.oidcjwksEndpoint).toBe(process.env.REAL_OIDCJWKS_ENDPOINT)
+      expect(process.env.jwtPrivateKeyArn).toBe(process.env.REAL_JWT_PRIVATE_KEY_ARN)
+      expect(process.env.userPoolIdp).toBe(process.env.REAL_USER_POOL_IDP)
+      expect(process.env.useSignedJWT).toBe(process.env.REAL_USE_SIGNED_JWT)
+      expect(process.env.oidcClientId).toBe(process.env.REAL_OIDC_CLIENT_ID)
+      expect(process.env.oidcIssuer).toBe(process.env.REAL_OIDC_ISSUER)
+    })
 
-  // eslint-disable-next-line max-len
-  it("should use mock environment variables when MOCK_MODE_ENABLED is true and username starts with Mock_", async () => {
-    process.env.MOCK_MODE_ENABLED = "true"
-    process.env.MOCK_IDP_TOKEN_PATH = "/mock/idp/token"
-    process.env.MOCK_USER_INFO_ENDPOINT = "https://mock-userinfo.com"
-    process.env.MOCK_OIDCJWKS_ENDPOINT = "https://mock-jwks.com"
-    process.env.MOCK_JWT_PRIVATE_KEY_ARN = "arn:aws:ssm:region:account-id:parameter/mock-key"
-    process.env.MOCK_USER_POOL_IDP = "MockPoolIdentityProvider"
-    process.env.MOCK_USE_SIGNED_JWT = "false"
-    process.env.MOCK_OIDC_CLIENT_ID = "mock-client-id"
-    process.env.MOCK_OIDC_ISSUER = "https://mock-oidc-issuer.com"
+  it(
+    "should use mock environment variables when MOCK_MODE_ENABLED is true " +
+    "and username starts with Mock_",
+    async () => {
+      process.env.MOCK_MODE_ENABLED = "true"
+      process.env.MOCK_IDP_TOKEN_PATH = "/mock/idp/token"
+      process.env.MOCK_USER_INFO_ENDPOINT = "https://mock-userinfo.com"
+      process.env.MOCK_OIDCJWKS_ENDPOINT = "https://mock-jwks.com"
+      process.env.MOCK_JWT_PRIVATE_KEY_ARN = "arn:aws:ssm:region:account-id:parameter/mock-key"
+      process.env.MOCK_USER_POOL_IDP = "MockPoolIdentityProvider"
+      process.env.MOCK_USE_SIGNED_JWT = "false"
+      process.env.MOCK_OIDC_CLIENT_ID = "mock-client-id"
+      process.env.MOCK_OIDC_ISSUER = "https://mock-oidc-issuer.com"
 
-    mockGetUsernameFromEvent.mockReturnValue("Mock_JaneDoe")
+      mockGetUsernameFromEvent.mockReturnValue("Mock_JaneDoe")
 
-    await handler(event, context)
-    expect(process.env.idpTokenPath).toBe(process.env.MOCK_IDP_TOKEN_PATH)
-    expect(process.env.userInfoEndpoint).toBe(process.env.MOCK_USER_INFO_ENDPOINT)
-    expect(process.env.oidcjwksEndpoint).toBe(process.env.MOCK_OIDCJWKS_ENDPOINT)
-    expect(process.env.jwtPrivateKeyArn).toBe(process.env.MOCK_JWT_PRIVATE_KEY_ARN)
-    expect(process.env.userPoolIdp).toBe(process.env.MOCK_USER_POOL_IDP)
-    expect(process.env.useSignedJWT).toBe(process.env.MOCK_USE_SIGNED_JWT)
-    expect(process.env.oidcClientId).toBe(process.env.MOCK_OIDC_CLIENT_ID)
-    expect(process.env.oidcIssuer).toBe(process.env.MOCK_OIDC_ISSUER)
-  })
+      await handler(event, context)
+      expect(process.env.idpTokenPath).toBe(process.env.MOCK_IDP_TOKEN_PATH)
+      expect(process.env.userInfoEndpoint).toBe(process.env.MOCK_USER_INFO_ENDPOINT)
+      expect(process.env.oidcjwksEndpoint).toBe(process.env.MOCK_OIDCJWKS_ENDPOINT)
+      expect(process.env.jwtPrivateKeyArn).toBe(process.env.MOCK_JWT_PRIVATE_KEY_ARN)
+      expect(process.env.userPoolIdp).toBe(process.env.MOCK_USER_POOL_IDP)
+      expect(process.env.useSignedJWT).toBe(process.env.MOCK_USE_SIGNED_JWT)
+      expect(process.env.oidcClientId).toBe(process.env.MOCK_OIDC_CLIENT_ID)
+      expect(process.env.oidcIssuer).toBe(process.env.MOCK_OIDC_ISSUER)
+    })
 
-  // eslint-disable-next-line max-len
-  it("should default to real environment variables if MOCK_MODE_ENABLED is true but username does not start with Mock_", async () => {
-    process.env.MOCK_MODE_ENABLED = "true"
-    mockGetUsernameFromEvent.mockReturnValue("Primary_JohnDoe")
-    await handler(event, context)
-    // Should still use real because username doesn't start with Mock_
-    expect(process.env.idpTokenPath).toBe(process.env.REAL_IDP_TOKEN_PATH)
-    expect(process.env.userInfoEndpoint).toBe(process.env.REAL_USER_INFO_ENDPOINT)
-    expect(process.env.oidcjwksEndpoint).toBe(process.env.REAL_OIDCJWKS_ENDPOINT)
-  })
+  it(
+    "should default to real environment variables if MOCK_MODE_ENABLED is true " +
+    "but username does not start with Mock_",
+    async () => {
+      process.env.MOCK_MODE_ENABLED = "true"
+      mockGetUsernameFromEvent.mockReturnValue("Primary_JohnDoe")
+      await handler(event, context)
+      // Should still use real because username doesn't start with Mock_
+      expect(process.env.idpTokenPath).toBe(process.env.REAL_IDP_TOKEN_PATH)
+      expect(process.env.userInfoEndpoint).toBe(process.env.REAL_USER_INFO_ENDPOINT)
+      expect(process.env.oidcjwksEndpoint).toBe(process.env.REAL_OIDCJWKS_ENDPOINT)
+    })
 
   it("should return 500 and log error when fetchAndVerifyCIS2Tokens throws an error", async () => {
     const error = new Error("Token verification failed")

--- a/packages/trackerUserInfoLambda/tests/test_handler.test.ts
+++ b/packages/trackerUserInfoLambda/tests/test_handler.test.ts
@@ -1,60 +1,210 @@
 import {jest} from "@jest/globals"
 
+// Mocked functions from cis2TokenHelpers
+const mockFetchAndVerifyCIS2Tokens = jest.fn()
+const mockGetUsernameFromEvent = jest.fn()
+
+jest.unstable_mockModule("@/cis2TokenHelpers", () => {
+  const fetchAndVerifyCIS2Tokens = mockFetchAndVerifyCIS2Tokens.mockImplementation(async () => {
+    return {
+      cis2IdToken: "idToken",
+      cis2AccessToken: "accessToken"
+    }
+  })
+
+  const getUsernameFromEvent = mockGetUsernameFromEvent.mockImplementation(() => {
+    return "Mock_JoeBloggs"
+  })
+
+  return {
+    fetchAndVerifyCIS2Tokens,
+    getUsernameFromEvent
+  }
+})
+
+// Mocked functions from userInfoHelpers
+const mockFetchUserInfo = jest.fn()
+const mockUpdateDynamoTable = jest.fn()
+
+jest.unstable_mockModule("@/userInfoHelpers", () => {
+  const fetchUserInfo = mockFetchUserInfo.mockImplementation(() => {
+    return {
+      roles_with_access: [],
+      roles_without_access: [],
+      selected_role: {}
+    }
+  })
+
+  const updateDynamoTable = mockUpdateDynamoTable.mockImplementation(() => {})
+  
+  return {
+    fetchUserInfo,
+    updateDynamoTable
+  }
+})
+
+
+const {handler} = await import("@/handler")
 import {mockContext, mockAPIGatewayProxyEvent} from "./mockObjects"
 
-// FIXME: These mocks are broken!
-jest.mock("../src/cis2TokenHelpers", () => {
+describe("Lambda Handler Tests", () => {
+  let event = {...mockAPIGatewayProxyEvent}
+  let context = {...mockContext}
 
-  const cis2AccessToken = "foo"
-  const cis2IdToken = "bar"
+  beforeEach(() => {
+    // Set default environment variables
+    process.env.MOCK_MODE_ENABLED = "false"
 
-  const username = "Mock_JoeBloggs"
+    process.env.REAL_IDP_TOKEN_PATH = "/real/idp/token"
+    process.env.REAL_USER_INFO_ENDPOINT = "https://real-userinfo.com"
+    process.env.REAL_OIDCJWKS_ENDPOINT = "https://real-jwks.com"
+    process.env.REAL_JWT_PRIVATE_KEY_ARN = "arn:aws:ssm:region:account-id:parameter/real-key"
+    process.env.REAL_USER_POOL_IDP = "RealPoolIdentityProvider"
+    process.env.REAL_USE_SIGNED_JWT = "true"
+    process.env.REAL_OIDC_CLIENT_ID = "real-client-id"
+    process.env.REAL_OIDC_ISSUER = "https://real-oidc-issuer.com"
+  
+    process.env.MOCK_IDP_TOKEN_PATH = "/mock/idp/token"
+    process.env.MOCK_USER_INFO_ENDPOINT = "https://mock-userinfo.com"
+    process.env.MOCK_OIDCJWKS_ENDPOINT = "https://mock-jwks.com"
+    process.env.MOCK_JWT_PRIVATE_KEY_ARN = "arn:aws:ssm:region:account-id:parameter/mock-key"
+    process.env.MOCK_USER_POOL_IDP = "MockPoolIdentityProvider"
+    process.env.MOCK_USE_SIGNED_JWT = "true"
+    process.env.MOCK_OIDC_CLIENT_ID = "mock-client-id"
+    process.env.MOCK_OIDC_ISSUER = "https://mock-oidc-issuer.com"
+  })
 
-  return {
-    fetchAndVerifyCIS2Tokens: jest.fn(() => Promise.resolve({cis2AccessToken, cis2IdToken})),
-    getUsernameFromEvent: jest.fn(() => username)
-  }
-})
+  it("should return a successful response when called normally", async () => {
+    const response = await handler(event, context)
 
-jest.mock("../src/userInfoHelpers", () => {
-  const userInfo = {
-    roles_with_access: [],
-    roles_without_access: [],
-    currently_selected_role: []
-  }
+    expect(mockFetchAndVerifyCIS2Tokens).toHaveBeenCalled()
+    expect(mockFetchUserInfo).toHaveBeenCalled()
+    expect(mockUpdateDynamoTable).toHaveBeenCalled()
 
-  return {
-    fetchUserInfo: jest.fn(() => Promise.resolve(userInfo)),
-    updateDynamoTable: jest.fn(() => true)
-  }
-})
+    expect(response).toBeDefined()
+    expect(response).toHaveProperty("statusCode", 200)
+    expect(response).toHaveProperty("body")
 
-beforeEach(() => {
-  jest.restoreAllMocks()
+    const body = JSON.parse(response.body)
+    expect(body).toHaveProperty("message", "UserInfo fetched successfully")
+    expect(body).toHaveProperty("userInfo")
+  })
 
-  // Set default environment variables if needed
-  process.env.MOCK_MODE_ENABLED = "false"
-  process.env.REAL_IDP_TOKEN_PATH = "/real/idp/token"
-  process.env.REAL_USER_INFO_ENDPOINT = "https://real-userinfo.com"
-  process.env.REAL_OIDCJWKS_ENDPOINT = "https://real-jwks.com"
-  process.env.REAL_JWT_PRIVATE_KEY_ARN = "arn:aws:ssm:region:account-id:parameter/real-key"
-  process.env.REAL_USER_POOL_IDP = "RealPoolIdentityProvider"
-  process.env.REAL_USE_SIGNED_JWT = "true"
-  process.env.REAL_OIDC_CLIENT_ID = "real-client-id"
-  process.env.REAL_OIDC_ISSUER = "https://real-oidc-issuer.com"
-})
+  it("should use real environment variables when MOCK_MODE_ENABLED is false and username does not start with Mock_", async () => {
+    mockGetUsernameFromEvent.mockReturnValue("Primary_JohnDoe")
+    await handler(event, context)
+    expect(mockGetUsernameFromEvent).toHaveBeenCalled()
+    expect(process.env.idpTokenPath).toBe(process.env.REAL_IDP_TOKEN_PATH)
+    expect(process.env.userInfoEndpoint).toBe(process.env.REAL_USER_INFO_ENDPOINT)
+    expect(process.env.oidcjwksEndpoint).toBe(process.env.REAL_OIDCJWKS_ENDPOINT)
+    expect(process.env.jwtPrivateKeyArn).toBe(process.env.REAL_JWT_PRIVATE_KEY_ARN)
+    expect(process.env.userPoolIdp).toBe(process.env.REAL_USER_POOL_IDP)
+    expect(process.env.useSignedJWT).toBe(process.env.REAL_USE_SIGNED_JWT)
+    expect(process.env.oidcClientId).toBe(process.env.REAL_OIDC_CLIENT_ID)
+    expect(process.env.oidcIssuer).toBe(process.env.REAL_OIDC_ISSUER)
+  })
 
-import {handler} from "../src/handler"
+  it("should use mock environment variables when MOCK_MODE_ENABLED is true and username starts with Mock_", async () => {
+    process.env.MOCK_MODE_ENABLED = "true"
+    process.env.MOCK_IDP_TOKEN_PATH = "/mock/idp/token"
+    process.env.MOCK_USER_INFO_ENDPOINT = "https://mock-userinfo.com"
+    process.env.MOCK_OIDCJWKS_ENDPOINT = "https://mock-jwks.com"
+    process.env.MOCK_JWT_PRIVATE_KEY_ARN = "arn:aws:ssm:region:account-id:parameter/mock-key"
+    process.env.MOCK_USER_POOL_IDP = "MockPoolIdentityProvider"
+    process.env.MOCK_USE_SIGNED_JWT = "false"
+    process.env.MOCK_OIDC_CLIENT_ID = "mock-client-id"
+    process.env.MOCK_OIDC_ISSUER = "https://mock-oidc-issuer.com"
+    
+    mockGetUsernameFromEvent.mockReturnValue("Mock_JaneDoe")
 
-describe("Basic handler invocation", () => {
-  let event = mockAPIGatewayProxyEvent
-  let context = mockContext
+    await handler(event, context)
+    expect(process.env.idpTokenPath).toBe(process.env.MOCK_IDP_TOKEN_PATH)
+    expect(process.env.userInfoEndpoint).toBe(process.env.MOCK_USER_INFO_ENDPOINT)
+    expect(process.env.oidcjwksEndpoint).toBe(process.env.MOCK_OIDCJWKS_ENDPOINT)
+    expect(process.env.jwtPrivateKeyArn).toBe(process.env.MOCK_JWT_PRIVATE_KEY_ARN)
+    expect(process.env.userPoolIdp).toBe(process.env.MOCK_USER_POOL_IDP)
+    expect(process.env.useSignedJWT).toBe(process.env.MOCK_USE_SIGNED_JWT)
+    expect(process.env.oidcClientId).toBe(process.env.MOCK_OIDC_CLIENT_ID)
+    expect(process.env.oidcIssuer).toBe(process.env.MOCK_OIDC_ISSUER)
+  })
 
-  it("should return a response when called", async () => {
+  it("should default to real environment variables if MOCK_MODE_ENABLED is true but username does not start with Mock_", async () => {
+    process.env.MOCK_MODE_ENABLED = "true"
+    mockGetUsernameFromEvent.mockReturnValue("Primary_JohnDoe")
+    await handler(event, context)
+    // Should still use real because username doesn't start with Mock_
+    expect(process.env.idpTokenPath).toBe(process.env.REAL_IDP_TOKEN_PATH)
+    expect(process.env.userInfoEndpoint).toBe(process.env.REAL_USER_INFO_ENDPOINT)
+    expect(process.env.oidcjwksEndpoint).toBe(process.env.REAL_OIDCJWKS_ENDPOINT)
+  })
+
+  it("should return 500 and log error when fetchAndVerifyCIS2Tokens throws an error", async () => {
+    const error = new Error("Token verification failed")
+    mockFetchAndVerifyCIS2Tokens.mockImplementation(async () => Promise.reject(error))
+    
+    console.log("???????????????????????")
+    const response = await handler(event, context)
+    console.log("response")
+    expect(response.statusCode).toBe(500)
+    const body = JSON.parse(response.body)
+    expect(body.message).toBe("Internal server error")
+    expect(mockFetchUserInfo).not.toHaveBeenCalled()
+    expect(mockUpdateDynamoTable).not.toHaveBeenCalled()
+  })
+
+  it("should return 500 and log error when fetchUserInfo throws an error", async () => {
+    const error = new Error("User info fetch failed")
+    mockFetchUserInfo.mockImplementation(async () => Promise.reject(error))
 
     const response = await handler(event, context)
-    expect(response).toBeDefined()
-    expect(response).toHaveProperty("statusCode")
-    expect(response).toHaveProperty("body")
+    expect(response.statusCode).toBe(500)
+    const body = JSON.parse(response.body)
+    expect(body.message).toBe("Internal server error")
+    expect(mockUpdateDynamoTable).not.toHaveBeenCalled()
+  })
+
+  it("should return 500 and log error when updateDynamoTable throws an error", async () => {
+    const error = new Error("Dynamo update failed")
+    mockUpdateDynamoTable.mockImplementation(() => { throw error })
+
+    const response = await handler(event, context)
+    expect(response.statusCode).toBe(500)
+    const body = JSON.parse(response.body)
+    expect(body.message).toBe("Internal server error")
+  })
+
+  it("should handle unexpected error types gracefully", async () => {
+    mockUpdateDynamoTable.mockImplementation(() => { throw "Unexpected error string" })
+
+    const response = await handler(event, context)
+    expect(response.statusCode).toBe(500)
+    const body = JSON.parse(response.body)
+    expect(body.message).toBe("Internal server error")
+  })
+
+  it("should call updateDynamoTable with the correct parameters", async () => {
+    const testUsername = "Primary_Tester"
+    mockGetUsernameFromEvent.mockReturnValue(testUsername)
+    const userInfoMock = {
+      roles_with_access: ["roleX"],
+      roles_without_access: ["roleY"],
+      currently_selected_role: ["roleX"]
+    }
+    mockFetchUserInfo.mockReturnValue(userInfoMock)
+
+    mockUpdateDynamoTable.mockImplementation(() => {
+      console.log("!!!!!!!!!!!!!!!")
+      return true
+    })
+
+    mockFetchAndVerifyCIS2Tokens.mockImplementation(async () => {
+      return {
+        cis2IdToken: "idToken",
+        cis2AccessToken: "accessToken"
+      }
+    })
+
+    await handler(event, context)
+    expect(mockUpdateDynamoTable).toHaveBeenCalledWith(testUsername, userInfoMock, expect.any(Object), expect.any(Object))
   })
 })

--- a/packages/trackerUserInfoLambda/tests/test_handler.test.ts
+++ b/packages/trackerUserInfoLambda/tests/test_handler.test.ts
@@ -36,13 +36,12 @@ jest.unstable_mockModule("@/userInfoHelpers", () => {
   })
 
   const updateDynamoTable = mockUpdateDynamoTable.mockImplementation(() => {})
-  
+
   return {
     fetchUserInfo,
     updateDynamoTable
   }
 })
-
 
 const {handler} = await import("@/handler")
 import {mockContext, mockAPIGatewayProxyEvent} from "./mockObjects"
@@ -63,7 +62,7 @@ describe("Lambda Handler Tests", () => {
     process.env.REAL_USE_SIGNED_JWT = "true"
     process.env.REAL_OIDC_CLIENT_ID = "real-client-id"
     process.env.REAL_OIDC_ISSUER = "https://real-oidc-issuer.com"
-  
+
     process.env.MOCK_IDP_TOKEN_PATH = "/mock/idp/token"
     process.env.MOCK_USER_INFO_ENDPOINT = "https://mock-userinfo.com"
     process.env.MOCK_OIDCJWKS_ENDPOINT = "https://mock-jwks.com"
@@ -90,6 +89,7 @@ describe("Lambda Handler Tests", () => {
     expect(body).toHaveProperty("userInfo")
   })
 
+  // eslint-disable-next-line max-len
   it("should use real environment variables when MOCK_MODE_ENABLED is false and username does not start with Mock_", async () => {
     mockGetUsernameFromEvent.mockReturnValue("Primary_JohnDoe")
     await handler(event, context)
@@ -104,6 +104,7 @@ describe("Lambda Handler Tests", () => {
     expect(process.env.oidcIssuer).toBe(process.env.REAL_OIDC_ISSUER)
   })
 
+  // eslint-disable-next-line max-len
   it("should use mock environment variables when MOCK_MODE_ENABLED is true and username starts with Mock_", async () => {
     process.env.MOCK_MODE_ENABLED = "true"
     process.env.MOCK_IDP_TOKEN_PATH = "/mock/idp/token"
@@ -114,7 +115,7 @@ describe("Lambda Handler Tests", () => {
     process.env.MOCK_USE_SIGNED_JWT = "false"
     process.env.MOCK_OIDC_CLIENT_ID = "mock-client-id"
     process.env.MOCK_OIDC_ISSUER = "https://mock-oidc-issuer.com"
-    
+
     mockGetUsernameFromEvent.mockReturnValue("Mock_JaneDoe")
 
     await handler(event, context)
@@ -128,6 +129,7 @@ describe("Lambda Handler Tests", () => {
     expect(process.env.oidcIssuer).toBe(process.env.MOCK_OIDC_ISSUER)
   })
 
+  // eslint-disable-next-line max-len
   it("should default to real environment variables if MOCK_MODE_ENABLED is true but username does not start with Mock_", async () => {
     process.env.MOCK_MODE_ENABLED = "true"
     mockGetUsernameFromEvent.mockReturnValue("Primary_JohnDoe")
@@ -141,7 +143,7 @@ describe("Lambda Handler Tests", () => {
   it("should return 500 and log error when fetchAndVerifyCIS2Tokens throws an error", async () => {
     const error = new Error("Token verification failed")
     mockFetchAndVerifyCIS2Tokens.mockImplementation(async () => Promise.reject(error))
-    
+
     console.log("???????????????????????")
     const response = await handler(event, context)
     console.log("response")
@@ -165,7 +167,9 @@ describe("Lambda Handler Tests", () => {
 
   it("should return 500 and log error when updateDynamoTable throws an error", async () => {
     const error = new Error("Dynamo update failed")
-    mockUpdateDynamoTable.mockImplementation(() => { throw error })
+    mockUpdateDynamoTable.mockImplementation(() => {
+      throw error
+    })
 
     const response = await handler(event, context)
     expect(response.statusCode).toBe(500)
@@ -174,7 +178,9 @@ describe("Lambda Handler Tests", () => {
   })
 
   it("should handle unexpected error types gracefully", async () => {
-    mockUpdateDynamoTable.mockImplementation(() => { throw "Unexpected error string" })
+    mockUpdateDynamoTable.mockImplementation(() => {
+      throw "Unexpected error string"
+    })
 
     const response = await handler(event, context)
     expect(response.statusCode).toBe(500)
@@ -205,6 +211,11 @@ describe("Lambda Handler Tests", () => {
     })
 
     await handler(event, context)
-    expect(mockUpdateDynamoTable).toHaveBeenCalledWith(testUsername, userInfoMock, expect.any(Object), expect.any(Object))
+    expect(mockUpdateDynamoTable).toHaveBeenCalledWith(
+      testUsername,
+      userInfoMock,
+      expect.any(Object),
+      expect.any(Object)
+    )
   })
 })

--- a/packages/trackerUserInfoLambda/tests/test_handler.test.ts
+++ b/packages/trackerUserInfoLambda/tests/test_handler.test.ts
@@ -1,6 +1,50 @@
-import { mockContext, mockAPIGatewayProxyEvent } from "./mockObjects"
+import {jest} from "@jest/globals"
 
-import { handler } from "../src/handler"
+import {mockContext, mockAPIGatewayProxyEvent} from "./mockObjects"
+
+// FIXME: These mocks are broken!
+jest.mock("../src/cis2TokenHelpers", () => {
+
+  const cis2AccessToken = "foo"
+  const cis2IdToken = "bar"
+
+  const username = "Mock_JoeBloggs"
+
+  return {
+    fetchAndVerifyCIS2Tokens: jest.fn(() => Promise.resolve({cis2AccessToken, cis2IdToken})),
+    getUsernameFromEvent: jest.fn(() => username)
+  }
+})
+
+jest.mock("../src/userInfoHelpers", () => {
+  const userInfo = {
+    roles_with_access: [],
+    roles_without_access: [],
+    currently_selected_role: []
+  }
+
+  return {
+    fetchUserInfo: jest.fn(() => Promise.resolve(userInfo)),
+    updateDynamoTable: jest.fn(() => true)
+  }
+})
+
+beforeEach(() => {
+  jest.restoreAllMocks()
+
+  // Set default environment variables if needed
+  process.env.MOCK_MODE_ENABLED = "false"
+  process.env.REAL_IDP_TOKEN_PATH = "/real/idp/token"
+  process.env.REAL_USER_INFO_ENDPOINT = "https://real-userinfo.com"
+  process.env.REAL_OIDCJWKS_ENDPOINT = "https://real-jwks.com"
+  process.env.REAL_JWT_PRIVATE_KEY_ARN = "arn:aws:ssm:region:account-id:parameter/real-key"
+  process.env.REAL_USER_POOL_IDP = "RealPoolIdentityProvider"
+  process.env.REAL_USE_SIGNED_JWT = "true"
+  process.env.REAL_OIDC_CLIENT_ID = "real-client-id"
+  process.env.REAL_OIDC_ISSUER = "https://real-oidc-issuer.com"
+})
+
+import {handler} from "../src/handler"
 
 describe("Basic handler invocation", () => {
   let event = mockAPIGatewayProxyEvent

--- a/packages/trackerUserInfoLambda/tsconfig.json
+++ b/packages/trackerUserInfoLambda/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "../../tsconfig.defaults.json",
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "lib"
+    "outDir": "lib",
+    "paths": 
+      {"@/*": ["./src/*"]}
+    
   },
   "include": ["src/**/*", "tests/**/*"],
   "exclude": ["node_modules"]

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,9 +2,6 @@ sonar.organization=nhsdigital
 sonar.projectKey=NHSDigital_eps-prescription-tracker-ui
 sonar.host.url=https://sonarcloud.io
 
-sonar.duplication.exclusions=\
-
-
 sonar.coverage.exclusions=\
     **/*.test.*, \
     **/mock*, \

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,6 +2,9 @@ sonar.organization=nhsdigital
 sonar.projectKey=NHSDigital_eps-prescription-tracker-ui
 sonar.host.url=https://sonarcloud.io
 
+sonar.duplication.exclusions=\
+
+
 sonar.coverage.exclusions=\
     **/*.test.*, \
     **/mock*, \
@@ -18,5 +21,7 @@ sonar.javascript.lcov.reportPaths=packages/cpt-ui/coverage/lcov.info, \
     packages/common/middyErrorHandler/coverage/lcov.info, \
     packages/trackerUserInfoLambda/coverage/lcov.info
 
-sonar.cpd.exclusions=packages/cloudfrontFunctions/tests/*, \
-    packages/auth_demo/**
+sonar.cpd.exclusions=\
+    packages/cloudfrontFunctions/tests/*, \
+    packages/auth_demo/**, \
+    **/mock*


### PR DESCRIPTION
## Summary

- :exclamation: Breaking Change

### Details

This is my attempt at making the lambda able to receive both real and mock auth tokens.

There's an environment variable that we can set to enable mock auth, and if it's present AND the user is using what appears to be a mock token, then we process it as such. Otherwise, we fall back on proper authentication.