### PR TITLE
Fix: [AEA-0000] - add nag supression for aws supplied lambda

### DIFF
--- a/packages/cdk/nagSuppressions.ts
+++ b/packages/cdk/nagSuppressions.ts
@@ -42,6 +42,17 @@ export const nagSuppressions = (stack: Stack) => {
       ]
     )
 
+    safeAddNagSuppression(
+      stack,
+      "/StatefulStack/AWS679f53fac002430cb0da5b7982bd2287/Resource",
+      [
+        {
+          id: "AwsSolutions-L1",
+          reason: "AWS supplied lambda does not use latest runtime"
+        }
+      ]
+    )
+
     safeAddNagSuppressionGroup(
       stack,
       [


### PR DESCRIPTION
## Summary

- Routine Change

### Details

- aws supplied lambda does not use latest runtime so add a nag suppression to ignore the error