### PR TITLE
New: [AEA-4959] - Create ping endpoint

### DIFF
--- a/.vscode/eps-prescription-tracker-ui.code-workspace
+++ b/.vscode/eps-prescription-tracker-ui.code-workspace
@@ -25,24 +25,8 @@
         "path": "../packages/cognito"
       },
       {
-        "name": "packages/prescriptionSearchLambda",
-        "path": "../packages/prescriptionSearchLambda"
-      },
-      {
-        "name": "packages/common/middyErrorHandler",
-        "path": "../packages/common/middyErrorHandler"
-      },
-      {
-        "name": "packages/common/testing",
-        "path": "../packages/common/testing"
-      },
-      {
-        "name": "packages/common/authFunctions",
-        "path": "../packages/common/authFunctions"
-      },
-      {
-        "name": "packages/auth_demo",
-        "path": "../packages/auth_demo"
+        "name": "packages/pingLambda",
+        "path": "../packages/pingLambda"
       },
       {
         "name": "packages/trackerUserInfoLambda",
@@ -51,7 +35,27 @@
       {
         "name": "packages/selectedRoleLambda",
         "path": "../packages/selectedRoleLambda"
-      }
+      },
+      {
+        "name": "packages/prescriptionSearchLambda",
+        "path": "../packages/prescriptionSearchLambda"
+      },
+      {
+        "name": "packages/common/middyErrorHandler",
+        "path": "../packages/common/middyErrorHandler"
+      },
+      {
+        "name": "packages/common/authFunctions",
+        "path": "../packages/common/authFunctions"
+      },
+      {
+        "name": "packages/common/testing",
+        "path": "../packages/common/testing"
+      },
+      {
+        "name": "packages/auth_demo",
+        "path": "../packages/auth_demo"
+      },
     ],
     "settings": {
       "jest.disabledWorkspaceFolders": [

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ lint-node: compile-node
 	npm run lint --workspace packages/common/middyErrorHandler
 	npm run lint --workspace packages/trackerUserInfoLambda
 	npm run lint --workspace packages/selectedRoleLambda
+	npm run lint --workspace packages/pingLambda
 	npm run lint --workspace packages/common/authFunctions
 
 lint-githubactions:
@@ -52,6 +53,7 @@ test: compile
 	npm run test --workspace packages/common/middyErrorHandler
 	npm run test --workspace packages/trackerUserInfoLambda
 	npm run test --workspace packages/selectedRoleLambda
+	npm run test --workspace packages/pingLambda
 	npm run test --workspace packages/common/authFunctions
 
 clean:
@@ -74,6 +76,8 @@ clean:
 	rm -rf packages/selectedRoleLambda/lib
 	rm -rf packages/common/authFunctions/coverage
 	rm -rf packages/common/authFunctions/lib
+	rm -rf packages/common/pingLambda/coverage
+	rm -rf packages/common/pingLambda/lib
 
 deep-clean: clean
 	rm -rf .venv
@@ -91,6 +95,7 @@ check-licenses-node:
 	npm run check-licenses --workspace packages/prescriptionSearchLambda
 	npm run check-licenses --workspace packages/trackerUserInfoLambda
 	npm run check-licenses --workspace packages/selectedRoleLambda
+	npm run check-licenses --workspace packages/pingLambda
 
 check-licenses-python:
 	scripts/check_python_licenses.sh

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
                 "packages/common/authFunctions",
                 "packages/auth_demo",
                 "packages/trackerUserInfoLambda",
-                "packages/selectedRoleLambda"
+                "packages/selectedRoleLambda",
+                "packages/pingLambda"
             ],
             "dependencies": {
                 "conventional-changelog-eslint": "^6.0.0",
@@ -26603,6 +26604,10 @@
                 "node": ">=4"
             }
         },
+        "node_modules/ping-lambda": {
+            "resolved": "packages/pingLambda",
+            "link": true
+        },
         "node_modules/pirates": {
             "version": "4.0.6",
             "license": "MIT",
@@ -35490,6 +35495,20 @@
             "bin": {
                 "uuid": "dist/esm/bin/uuid"
             }
+        },
+        "packages/pingLambda": {
+            "name": "ping-lambda",
+            "version": "1.0.0",
+            "license": "MIT",
+            "dependencies": {
+                "@aws-lambda-powertools/logger": "^2.13.1",
+                "@cpt-ui-common/middyErrorHandler": "^1.0.0",
+                "@cpt-ui-common/testing": "^1.0.0",
+                "@middy/core": "^6.0.0",
+                "@middy/input-output-logger": "^6.0.0",
+                "aws-lambda": "^1.0.7"
+            },
+            "devDependencies": {}
         },
         "packages/prescriptionSearchLambda": {
             "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
         "packages/common/authFunctions",
         "packages/auth_demo",
         "packages/trackerUserInfoLambda",
-        "packages/selectedRoleLambda"
+        "packages/selectedRoleLambda",
+        "packages/pingLambda"
     ],
     "devDependencies": {
         "@semantic-release/changelog": "^6.0.3",

--- a/packages/cdk/nagSuppressions.ts
+++ b/packages/cdk/nagSuppressions.ts
@@ -191,6 +191,37 @@ export const nagSuppressions = (stack: Stack) => {
       ]
     )
 
+    // Ping Lambda
+    safeAddNagSuppression(
+      stack,
+      "/StatelessStack/ApiFunctions/Ping/LambdaPutLogsManagedPolicy/Resource",
+      [
+        {
+          id: "AwsSolutions-IAM5",
+          reason:
+            "Lambda logging policies need wildcard permissions to allow for dynamic log streams. This is acceptable for this lambda."
+        }
+      ]
+    )
+
+    // Ping Lambda
+    safeAddNagSuppression(
+      stack,
+      "/StatelessStack/ApiGateway/ApiGateway/Default/ping/GET/Resource",
+      [
+        {
+          id: "AwsSolutions-APIG4",
+          reason:
+            "The ping endpoint is intentionally open (public) and does not require authorization."
+        },
+        {
+          id: "AwsSolutions-COG4",
+          reason:
+            "The ping endpoint is intentionally open (public) and does not use a Cognito user pool authorizer."
+        }
+      ]
+    )
+
   }
 }
 

--- a/packages/cdk/resources/RestApiGatewayMethods.ts
+++ b/packages/cdk/resources/RestApiGatewayMethods.ts
@@ -16,6 +16,7 @@ export interface RestApiGatewayMethodsProps {
   readonly restApiGateway: RestApi
   readonly tokenLambda: NodejsFunction
   readonly mockTokenLambda: NodejsFunction
+  readonly pingLambda: NodejsFunction
   readonly prescriptionSearchLambda: NodejsFunction
   readonly trackerUserInfoLambda: NodejsFunction
   readonly selectedRoleLambda: NodejsFunction
@@ -40,6 +41,12 @@ export class RestApiGatewayMethods extends Construct {
     }
     const tokenResource = props.restApiGateway.root.addResource("token")
     tokenResource.addMethod("POST", new LambdaIntegration(props.tokenLambda, {
+      credentialsRole: props.restAPiGatewayRole
+    }))
+
+    // Add ping endpoint **without authorization**
+    const pingResource = props.restApiGateway.root.addResource("ping")
+    pingResource.addMethod("GET", new LambdaIntegration(props.pingLambda, {
       credentialsRole: props.restAPiGatewayRole
     }))
 

--- a/packages/cdk/resources/api/apiFunctions.ts
+++ b/packages/cdk/resources/api/apiFunctions.ts
@@ -47,6 +47,7 @@ export class ApiFunctions extends Construct {
   public readonly prescriptionSearchLambda: NodejsFunction
   public readonly trackerUserInfoLambda: NodejsFunction
   public readonly selectedRoleLambda: NodejsFunction
+  public readonly pingLambda: NodejsFunction
   public readonly primaryJwtPrivateKey: Secret
 
   public constructor(scope: Construct, id: string, props: ApiFunctionsProps) {
@@ -108,6 +109,22 @@ export class ApiFunctions extends Construct {
 
     // Add the policy to apiFunctionsPolicies
     apiFunctionsPolicies.push(trackerUserInfoLambda.executeLambdaManagedPolicy)
+
+    // Ping Lambda Function
+    const pingLambda = new LambdaFunction(this, "Ping", {
+      serviceName: props.serviceName,
+      stackName: props.stackName,
+      lambdaName: `${props.stackName}-ping`,
+      additionalPolicies: [],
+      logRetentionInDays: props.logRetentionInDays,
+      logLevel: props.logLevel,
+      packageBasePath: "packages/pingLambda",
+      entryPoint: "src/handler.ts",
+      lambdaEnvironmentVariables: commonLambdaEnv
+    })
+
+    // Add the policy to apiFunctionsPolicies
+    apiFunctionsPolicies.push(pingLambda.executeLambdaManagedPolicy)
 
     // Selected Role Lambda Function
     const selectedRoleLambda = new LambdaFunction(this, "SelectedRole", {
@@ -173,6 +190,7 @@ export class ApiFunctions extends Construct {
     this.apiFunctionsPolicies = apiFunctionsPolicies
     this.primaryJwtPrivateKey = props.sharedSecrets.primaryJwtPrivateKey
 
+    this.pingLambda = pingLambda.lambda
     this.prescriptionSearchLambda = prescriptionSearchLambda.lambda
     this.trackerUserInfoLambda = trackerUserInfoLambda.lambda
     this.selectedRoleLambda = selectedRoleLambda.lambda

--- a/packages/cdk/stacks/StatelessResourcesStack.ts
+++ b/packages/cdk/stacks/StatelessResourcesStack.ts
@@ -215,6 +215,7 @@ export class StatelessResourcesStack extends Stack {
       prescriptionSearchLambda: apiFunctions.prescriptionSearchLambda,
       trackerUserInfoLambda: apiFunctions.trackerUserInfoLambda,
       selectedRoleLambda: apiFunctions.selectedRoleLambda,
+      pingLambda: apiFunctions.pingLambda,
       useMockOidc: useMockOidc,
       authorizer: apiGateway.authorizer
     })

--- a/packages/pingLambda/.vscode/launch.json
+++ b/packages/pingLambda/.vscode/launch.json
@@ -1,0 +1,32 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "name": "vscode-jest-tests.v2",
+            "request": "launch",
+            "args": [
+                "--runInBand",
+                "--watchAll=false",
+                "--testNamePattern",
+                "${jest.testNamePattern}",
+                "--runTestsByPath",
+                "${jest.testFile}",
+                "--config",
+                "${workspaceFolder}/jest.debug.config.ts"
+            ],
+            "cwd": "${workspaceFolder}",
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
+            "disableOptimisticBPs": true,
+            "program": "${workspaceFolder}/../../node_modules/.bin/jest",
+            "windows": {
+                "program": "${workspaceFolder}/node_modules/jest/bin/jest"
+            },
+            "env": {
+                "POWERTOOLS_DEV": true,
+                "NODE_OPTIONS": "--experimental-vm-modules"
+            }
+        }
+    ]
+}

--- a/packages/pingLambda/.vscode/settings.json
+++ b/packages/pingLambda/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "jest.jestCommandLine": "/workspaces/eps-prescription-tracker-ui/node_modules/.bin/jest --no-cache",
+    "jest.nodeEnv": {
+      "POWERTOOLS_DEV": true,
+      "NODE_OPTIONS": "--experimental-vm-modules"
+    }
+  }

--- a/packages/pingLambda/jest.config.ts
+++ b/packages/pingLambda/jest.config.ts
@@ -1,0 +1,10 @@
+import defaultConfig from "../../jest.default.config"
+import type {JestConfigWithTsJest} from "ts-jest"
+
+const jestConfig: JestConfigWithTsJest = {
+  ...defaultConfig,
+  "rootDir": "./",
+  moduleNameMapper: {"@/(.*)$": ["<rootDir>/src/$1"]}
+}
+
+export default jestConfig

--- a/packages/pingLambda/jest.debug.config.ts
+++ b/packages/pingLambda/jest.debug.config.ts
@@ -1,0 +1,9 @@
+import config from "./jest.config"
+import type {JestConfigWithTsJest} from "ts-jest"
+
+const debugConfig: JestConfigWithTsJest = {
+  ...config,
+  "preset": "ts-jest"
+}
+
+export default debugConfig

--- a/packages/pingLambda/package.json
+++ b/packages/pingLambda/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "ping-lambda",
+  "version": "1.0.0",
+  "description": "Healthcheck. Responds to pings, with pongs.",
+  "main": "handler.ts",
+  "author": "NHS Digital",
+  "license": "MIT",
+  "scripts": {
+    "unit": "POWERTOOLS_DEV=true NODE_OPTIONS=--experimental-vm-modules jest --no-cache --coverage",
+    "lint": "eslint  --max-warnings 0 --fix --config ../../eslint.config.mjs .",
+    "compile": "tsc",
+    "test": "npm run compile && npm run unit",
+    "check-licenses": "license-checker --failOn GPL --failOn LGPL --start ../.."
+  },
+  "dependencies": {
+    "@aws-lambda-powertools/logger": "^2.13.1",
+    "@cpt-ui-common/middyErrorHandler": "^1.0.0",
+    "@cpt-ui-common/testing": "^1.0.0",
+    "@middy/core": "^6.0.0",
+    "@middy/input-output-logger": "^6.0.0",
+    "aws-lambda": "^1.0.7"
+  },
+  "devDependencies": {}
+}

--- a/packages/pingLambda/src/handler.ts
+++ b/packages/pingLambda/src/handler.ts
@@ -1,0 +1,37 @@
+import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda"
+
+import {Logger} from "@aws-lambda-powertools/logger"
+import {injectLambdaContext} from "@aws-lambda-powertools/logger/middleware"
+
+import middy from "@middy/core"
+import inputOutputLogger from "@middy/input-output-logger"
+import {MiddyErrorHandler} from "@cpt-ui-common/middyErrorHandler"
+
+const logger = new Logger({serviceName: "pingPong"})
+
+const errorResponseBody = {
+  message: "A system error has occurred"
+}
+
+const middyErrorHandler = new MiddyErrorHandler(errorResponseBody)
+
+const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+  logger.appendKeys({"apigw-request-id": event.requestContext?.requestId})
+  logger.info("PING handler invoked", {event})
+
+  return {
+    statusCode: 200,
+    body: "PONG"
+  }
+}
+
+export const handler = middy(lambdaHandler)
+  .use(injectLambdaContext(logger, {clearState: true}))
+  .use(
+    inputOutputLogger({
+      logger: (request) => {
+        logger.info(request)
+      }
+    })
+  )
+  .use(middyErrorHandler.errorHandler({logger: logger}))

--- a/packages/pingLambda/tests/handler.test.ts
+++ b/packages/pingLambda/tests/handler.test.ts
@@ -1,0 +1,64 @@
+import {jest} from "@jest/globals"
+
+import {APIGatewayProxyEvent} from "aws-lambda"
+import {handler as originalHandler} from "../src/handler"
+import {Logger} from "@aws-lambda-powertools/logger"
+
+import {mockAPIGatewayProxyEvent} from "@cpt-ui-common/testing"
+
+describe("pingPong lambda handler", () => {
+  let event: APIGatewayProxyEvent
+
+  beforeEach(() => {
+    // Create a fake API Gateway event
+    event = {...mockAPIGatewayProxyEvent}
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it("returns 200 and 'PONG' in the response", async () => {
+    const response = await originalHandler(event, {})
+    expect(response.statusCode).toBe(200)
+    expect(response.body).toBe("PONG")
+  })
+
+  it("logs the invocation", async () => {
+    // Spy on logger methods. (The lambda creates its own logger instance,
+    // so we spy on the Logger prototype methods.)
+    const appendSpy = jest.spyOn(Logger.prototype, "appendKeys").mockImplementation(() => {})
+    const infoSpy = jest.spyOn(Logger.prototype, "info").mockImplementation(() => {})
+
+    await originalHandler(event, {})
+
+    // Check that the handler appended the "apigw-request-id" key to the logger.
+    expect(appendSpy).toHaveBeenLastCalledWith({"apigw-request-id": event.requestContext?.requestId})
+
+    // And that it logged the "PING handler invoked" message.
+    const loggedInvocation = infoSpy.mock.calls.some(call => {
+      const msg = call[0]
+      return typeof msg === "string" && msg.includes("PING handler invoked")
+    })
+    expect(loggedInvocation).toBe(true)
+  })
+
+  it("handles errors using the MiddyErrorHandler", async () => {
+    const simulatedErrorMessage = "Simulated error"
+    // Force an error by making appendKeys throw an error.
+    jest
+      .spyOn(Logger.prototype, "appendKeys")
+      .mockImplementation(() => {
+        throw new Error(simulatedErrorMessage)
+      })
+
+    // Call the handler. The error thrown in appendKeys should be caught by the error handler middleware.
+    const response = await originalHandler(event, {})
+
+    // The MiddyErrorHandler is set up with an error response body:
+    // { message: "A system error has occurred" }
+    expect(response).toEqual({
+      message: "A system error has occurred"
+    })
+  })
+})

--- a/packages/pingLambda/tsconfig.json
+++ b/packages/pingLambda/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.defaults.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "lib",
+    "paths": 
+      {"@/*": ["./src/*"]}
+    
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules"],
+  "references": [
+    {
+      "path": "../common/testing"
+    },
+    {
+      "path": "../common/middyErrorHandler"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- :sparkles: New Feature

### Details

Adds a simple healthcheck endpoint. Ping it with a GET request, and it responds with `[200, PONG]`. 

`/ping` is the route.

This will be used in the regression tests, to make sure the API is deploying (mostly) correctly.