### PR TITLE
New: [AEA-4752] - GET /prescriptionDetails

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -82,7 +82,7 @@ jobs:
       useCustomCognitoDomain: false
       APIGEE_CIS2_TOKEN_ENDPOINT: "https://internal-dev.api.service.nhs.uk/oauth2/token"
       APIGEE_MOCK_TOKEN_ENDPOINT: "https://internal-dev.api.service.nhs.uk/oauth2-mock/token"
-      APIGEE_PRESCRIPTIONS_ENDPOINT: "https://internal-dev.api.service.nhs.uk/clinical-prescription-tracker/"
+      APIGEE_PRESCRIPTIONS_ENDPOINT: "https://internal-dev.api.service.nhs.uk/clinical-prescription-tracker-pr-809/"
       JWT_KID: "eps-cpt-ui-test"
       # this needs uncommenting and above line deleted once it is merged
       # JWT_KID: "eps-cpt-ui-dev"

--- a/.vscode/eps-prescription-tracker-ui.code-workspace
+++ b/.vscode/eps-prescription-tracker-ui.code-workspace
@@ -29,6 +29,10 @@
         "path": "../packages/prescriptionSearchLambda"
       },
       {
+        "name": "packages/prescriptionDetailsLambda",
+        "path": "../packages/prescriptionDetailsLambda"
+      },
+      {
         "name": "packages/common/middyErrorHandler",
         "path": "../packages/common/middyErrorHandler"
       },
@@ -51,10 +55,6 @@
       {
         "name": "packages/selectedRoleLambda",
         "path": "../packages/selectedRoleLambda"
-      },
-      {
-        "name": "packages/prescriptionDetailsLambda",
-        "path": "../packages/prescriptionDetailsLambda"
       }
     ],
     "settings": {

--- a/.vscode/eps-prescription-tracker-ui.code-workspace
+++ b/.vscode/eps-prescription-tracker-ui.code-workspace
@@ -51,6 +51,10 @@
       {
         "name": "packages/selectedRoleLambda",
         "path": "../packages/selectedRoleLambda"
+      },
+      {
+        "name": "packages/prescriptionDetailsLambda",
+        "path": "../packages/prescriptionDetailsLambda"
       }
     ],
     "settings": {

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ lint-node: compile-node
 	npm run lint --workspace packages/cdk
 	npm run lint --workspace packages/cognito
 	npm run lint --workspace packages/prescriptionSearchLambda
+	npm run lint --workspace packages/prescriptionDetailsLambda
 	npm run lint --workspace packages/common/testing
 	npm run lint --workspace packages/common/middyErrorHandler
 	npm run lint --workspace packages/trackerUserInfoLambda
@@ -63,6 +64,8 @@ clean:
 	rm -rf packages/cognito/lib
 	rm -rf packages/prescriptionSearchLambda/coverage
 	rm -rf packages/prescriptionSearchLambda/lib
+	rm -rf packages/prescriptionDetailsLambda/coverage
+	rm -rf packages/prescriptionDetailsLambda/lib
 	rm -rf packages/common/middyErrorHandler/coverage
 	rm -rf packages/common/middyErrorHandler/lib
 	rm -rf cdk.out
@@ -89,6 +92,7 @@ check-licenses-node:
 	npm run check-licenses --workspace packages/common/authFunctions
 	npm run check-licenses --workspace packages/cognito
 	npm run check-licenses --workspace packages/prescriptionSearchLambda
+	npm run check-licenses --workspace packages/prescriptionDetailsLambda
 	npm run check-licenses --workspace packages/trackerUserInfoLambda
 	npm run check-licenses --workspace packages/selectedRoleLambda
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9817,6 +9817,66 @@
                 "fast-glob": "3.3.1"
             }
         },
+        "node_modules/@next/swc-darwin-arm64": {
+            "version": "15.1.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.1.4.tgz",
+            "integrity": "sha512-wBEMBs+np+R5ozN1F8Y8d/Dycns2COhRnkxRc+rvnbXke5uZBHkUGFgWxfTXn5rx7OLijuUhyfB+gC/ap58dDw==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@next/swc-darwin-x64": {
+            "version": "15.1.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.1.4.tgz",
+            "integrity": "sha512-7sgf5rM7Z81V9w48F02Zz6DgEJulavC0jadab4ZsJ+K2sxMNK0/BtF8J8J3CxnsJN3DGcIdC260wEKssKTukUw==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@next/swc-linux-arm64-gnu": {
+            "version": "15.1.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.1.4.tgz",
+            "integrity": "sha512-JaZlIMNaJenfd55kjaLWMfok+vWBlcRxqnRoZrhFQrhM1uAehP3R0+Aoe+bZOogqlZvAz53nY/k3ZyuKDtT2zQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@next/swc-linux-arm64-musl": {
+            "version": "15.1.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.1.4.tgz",
+            "integrity": "sha512-7EBBjNoyTO2ipMDgCiORpwwOf5tIueFntKjcN3NK+GAQD7OzFJe84p7a2eQUeWdpzZvhVXuAtIen8QcH71ZCOQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
         "node_modules/@next/swc-linux-x64-gnu": {
             "version": "15.1.4",
             "cpu": [
@@ -9840,6 +9900,36 @@
             "optional": true,
             "os": [
                 "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@next/swc-win32-arm64-msvc": {
+            "version": "15.1.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.1.4.tgz",
+            "integrity": "sha512-JgFCiV4libQavwII+kncMCl30st0JVxpPOtzWcAI2jtum4HjYaclobKhj+JsRu5tFqMtA5CJIa0MvYyuu9xjjQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@next/swc-win32-x64-msvc": {
+            "version": "15.1.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.1.4.tgz",
+            "integrity": "sha512-xxsJy9wzq7FR5SqPCUqdgSXiNXrMuidgckBa8nH9HtjjxsilgcN6VgXF6tZ3uEWuVEadotQJI8/9EQ6guTC4Yw==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
             ],
             "engines": {
                 "node": ">= 10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9817,66 +9817,6 @@
                 "fast-glob": "3.3.1"
             }
         },
-        "node_modules/@next/swc-darwin-arm64": {
-            "version": "15.1.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.1.4.tgz",
-            "integrity": "sha512-wBEMBs+np+R5ozN1F8Y8d/Dycns2COhRnkxRc+rvnbXke5uZBHkUGFgWxfTXn5rx7OLijuUhyfB+gC/ap58dDw==",
-            "cpu": [
-                "arm64"
-            ],
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@next/swc-darwin-x64": {
-            "version": "15.1.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.1.4.tgz",
-            "integrity": "sha512-7sgf5rM7Z81V9w48F02Zz6DgEJulavC0jadab4ZsJ+K2sxMNK0/BtF8J8J3CxnsJN3DGcIdC260wEKssKTukUw==",
-            "cpu": [
-                "x64"
-            ],
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@next/swc-linux-arm64-gnu": {
-            "version": "15.1.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.1.4.tgz",
-            "integrity": "sha512-JaZlIMNaJenfd55kjaLWMfok+vWBlcRxqnRoZrhFQrhM1uAehP3R0+Aoe+bZOogqlZvAz53nY/k3ZyuKDtT2zQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@next/swc-linux-arm64-musl": {
-            "version": "15.1.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.1.4.tgz",
-            "integrity": "sha512-7EBBjNoyTO2ipMDgCiORpwwOf5tIueFntKjcN3NK+GAQD7OzFJe84p7a2eQUeWdpzZvhVXuAtIen8QcH71ZCOQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
         "node_modules/@next/swc-linux-x64-gnu": {
             "version": "15.1.4",
             "cpu": [
@@ -9900,36 +9840,6 @@
             "optional": true,
             "os": [
                 "linux"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@next/swc-win32-arm64-msvc": {
-            "version": "15.1.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.1.4.tgz",
-            "integrity": "sha512-JgFCiV4libQavwII+kncMCl30st0JVxpPOtzWcAI2jtum4HjYaclobKhj+JsRu5tFqMtA5CJIa0MvYyuu9xjjQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@next/swc-win32-x64-msvc": {
-            "version": "15.1.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.1.4.tgz",
-            "integrity": "sha512-xxsJy9wzq7FR5SqPCUqdgSXiNXrMuidgckBa8nH9HtjjxsilgcN6VgXF6tZ3uEWuVEadotQJI8/9EQ6guTC4Yw==",
-            "cpu": [
-                "x64"
-            ],
-            "optional": true,
-            "os": [
-                "win32"
             ],
             "engines": {
                 "node": ">= 10"
@@ -18561,20 +18471,6 @@
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "license": "ISC"
-        },
-        "node_modules/fsevents": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-            "hasInstallScript": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-            }
         },
         "node_modules/function-bind": {
             "version": "1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
                 "packages/cdk",
                 "packages/cognito",
                 "packages/prescriptionSearchLambda",
+                "packages/prescriptionDetailsLambda",
                 "packages/common/middyErrorHandler",
                 "packages/common/testing",
                 "packages/common/authFunctions",
@@ -27487,6 +27488,10 @@
                 "node": ">= 0.8.0"
             }
         },
+        "node_modules/prescriptionDetailsLambda": {
+            "resolved": "packages/prescriptionDetailsLambda",
+            "link": true
+        },
         "node_modules/prescriptionSearchLambda": {
             "resolved": "packages/prescriptionSearchLambda",
             "link": true
@@ -34977,6 +34982,46 @@
         },
         "packages/cpt-ui/node_modules/uuid": {
             "version": "11.0.5",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/esm/bin/uuid"
+            }
+        },
+        "packages/prescriptionDetailsLambda": {
+            "version": "1.0.0",
+            "license": "MIT",
+            "dependencies": {
+                "@aws-lambda-powertools/commons": "^2.12.0",
+                "@aws-lambda-powertools/logger": "^2.13.1",
+                "@aws-lambda-powertools/parameters": "^2.13.0",
+                "@aws-sdk/client-dynamodb": "^3.741.0",
+                "@aws-sdk/client-secrets-manager": "^3.743.0",
+                "@aws-sdk/lib-dynamodb": "^3.734.0",
+                "@cpt-ui-common/authFunctions": "^1.0.0",
+                "@cpt-ui-common/middyErrorHandler": "^1.0.0",
+                "@middy/core": "^6.0.0",
+                "@middy/input-output-logger": "^6.0.0",
+                "aws-lambda": "^1.0.7",
+                "axios": "^1.7.7",
+                "jsonwebtoken": "^9.0.2",
+                "jwks-rsa": "^3.1.0",
+                "uuid": "^11.0.5"
+            },
+            "devDependencies": {
+                "@types/aws-lambda": "^8.10.147",
+                "axios-mock-adapter": "^2.0.0",
+                "mock-jwks": "^3.2.2",
+                "nock": "^14.0.0"
+            }
+        },
+        "packages/prescriptionDetailsLambda/node_modules/uuid": {
+            "version": "11.0.5",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.5.tgz",
+            "integrity": "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==",
             "funding": [
                 "https://github.com/sponsors/broofa",
                 "https://github.com/sponsors/ctavan"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "packages/cdk",
         "packages/cognito",
         "packages/prescriptionSearchLambda",
+        "packages/prescriptionDetailsLambda",
         "packages/common/middyErrorHandler",
         "packages/common/testing",
         "packages/common/authFunctions",

--- a/packages/cdk/nagSuppressions.ts
+++ b/packages/cdk/nagSuppressions.ts
@@ -156,6 +156,17 @@ export const nagSuppressions = (stack: Stack) => {
 
     safeAddNagSuppression(
       stack,
+      "/StatelessStack/ApiFunctions/PrescriptionDetails/LambdaPutLogsManagedPolicy/Resource",
+      [
+        {
+          id: "AwsSolutions-IAM5",
+          reason: "Suppress error for not having wildcards in permissions. This is a fine as we need to have permissions on all log streams under path"
+        }
+      ]
+    )
+
+    safeAddNagSuppression(
+      stack,
       "/StatelessStack/ApiGateway/ApiGateway/Default/mocknoauth/GET/Resource",
       [
         {

--- a/packages/cdk/resources/RestApiGatewayMethods.ts
+++ b/packages/cdk/resources/RestApiGatewayMethods.ts
@@ -17,6 +17,7 @@ export interface RestApiGatewayMethodsProps {
   readonly tokenLambda: NodejsFunction
   readonly mockTokenLambda: NodejsFunction
   readonly prescriptionSearchLambda: NodejsFunction
+  readonly prescriptionDetailsLambda: NodejsFunction
   readonly trackerUserInfoLambda: NodejsFunction
   readonly selectedRoleLambda: NodejsFunction
   readonly useMockOidc: boolean
@@ -54,6 +55,15 @@ export class RestApiGatewayMethods extends Construct {
     // prescription-search endpoint
     const prescriptionSearchLambdaResource = props.restApiGateway.root.addResource("prescription-search")
     prescriptionSearchLambdaResource.addMethod("GET", new LambdaIntegration(props.prescriptionSearchLambda, {
+      credentialsRole: props.restAPiGatewayRole
+    }), {
+      authorizationType: AuthorizationType.COGNITO,
+      authorizer: props.authorizer
+    })
+
+    // prescription-details endpoint
+    const prescriptionDetailsLambdaResource = props.restApiGateway.root.addResource("prescription-details")
+    prescriptionDetailsLambdaResource.addMethod("GET", new LambdaIntegration(props.prescriptionDetailsLambda, {
       credentialsRole: props.restAPiGatewayRole
     }), {
       authorizationType: AuthorizationType.COGNITO,

--- a/packages/cdk/stacks/StatelessResourcesStack.ts
+++ b/packages/cdk/stacks/StatelessResourcesStack.ts
@@ -213,6 +213,7 @@ export class StatelessResourcesStack extends Stack {
       tokenLambda: cognitoFunctions.tokenLambda,
       mockTokenLambda: cognitoFunctions.mockTokenLambda,
       prescriptionSearchLambda: apiFunctions.prescriptionSearchLambda,
+      prescriptionDetailsLambda: apiFunctions.prescriptionDetailsLambda,
       trackerUserInfoLambda: apiFunctions.trackerUserInfoLambda,
       selectedRoleLambda: apiFunctions.selectedRoleLambda,
       useMockOidc: useMockOidc,

--- a/packages/prescriptionDetailsLambda/.vscode/launch.json
+++ b/packages/prescriptionDetailsLambda/.vscode/launch.json
@@ -1,0 +1,32 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "name": "vscode-jest-tests.v2",
+            "request": "launch",
+            "args": [
+                "--runInBand",
+                "--watchAll=false",
+                "--testNamePattern",
+                "${jest.testNamePattern}",
+                "--runTestsByPath",
+                "${jest.testFile}",
+                "--config",
+                "${workspaceFolder}/jest.debug.config.ts"
+            ],
+            "cwd": "${workspaceFolder}",
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
+            "disableOptimisticBPs": true,
+            "program": "${workspaceFolder}/../../node_modules/.bin/jest",
+            "windows": {
+                "program": "${workspaceFolder}/node_modules/jest/bin/jest"
+            },
+            "env": {
+                "POWERTOOLS_DEV": true,
+                "NODE_OPTIONS": "--experimental-vm-modules"
+            }
+        }
+    ]
+}

--- a/packages/prescriptionDetailsLambda/.vscode/settings.json
+++ b/packages/prescriptionDetailsLambda/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "jest.jestCommandLine": "/workspaces/eps-prescription-tracker-ui/node_modules/.bin/jest --no-cache",
+    "jest.nodeEnv": {
+      "POWERTOOLS_DEV": true,
+      "NODE_OPTIONS": "--experimental-vm-modules"
+    }
+  }

--- a/packages/prescriptionDetailsLambda/jest.config.ts
+++ b/packages/prescriptionDetailsLambda/jest.config.ts
@@ -1,0 +1,10 @@
+import defaultConfig from "../../jest.default.config"
+import type {JestConfigWithTsJest} from "ts-jest"
+
+const jestConfig: JestConfigWithTsJest = {
+  ...defaultConfig,
+  "rootDir": "./",
+  setupFiles: ["<rootDir>/.jest/setEnvVars.js"]
+}
+
+export default jestConfig

--- a/packages/prescriptionDetailsLambda/jest.debug.config.ts
+++ b/packages/prescriptionDetailsLambda/jest.debug.config.ts
@@ -1,0 +1,9 @@
+import config from "./jest.config"
+import type {JestConfigWithTsJest} from "ts-jest"
+
+const debugConfig: JestConfigWithTsJest = {
+  ...config,
+  "preset": "ts-jest"
+}
+
+export default debugConfig

--- a/packages/prescriptionDetailsLambda/package.json
+++ b/packages/prescriptionDetailsLambda/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "prescriptionDetailsLambda",
+  "version": "1.0.0",
+  "description": "Lambda for prescription details",
+  "main": "handler.ts",
+  "author": "NHS Digital",
+  "license": "MIT",
+  "scripts": {
+    "unit": "POWERTOOLS_DEV=true NODE_OPTIONS=--experimental-vm-modules jest --no-cache --coverage",
+    "lint": "eslint  --max-warnings 0 --fix --config ../../eslint.config.mjs .",
+    "compile": "tsc",
+    "test": "npm run compile && npm run unit",
+    "check-licenses": "license-checker --failOn GPL --failOn LGPL --start ../.."
+  },
+  "dependencies": {
+    "@aws-lambda-powertools/commons": "^2.12.0",
+    "@aws-lambda-powertools/logger": "^2.13.1",
+    "@aws-lambda-powertools/parameters": "^2.13.0",
+    "@aws-sdk/client-dynamodb": "^3.741.0",
+    "@aws-sdk/client-secrets-manager": "^3.743.0",
+    "@aws-sdk/lib-dynamodb": "^3.734.0",
+    "@cpt-ui-common/authFunctions": "^1.0.0",
+    "@cpt-ui-common/middyErrorHandler": "^1.0.0",
+    "@middy/core": "^6.0.0",
+    "@middy/input-output-logger": "^6.0.0",
+    "aws-lambda": "^1.0.7",
+    "axios": "^1.7.7",
+    "jsonwebtoken": "^9.0.2",
+    "jwks-rsa": "^3.1.0",
+    "uuid": "^11.0.5"
+  },
+  "devDependencies": {
+    "@types/aws-lambda": "^8.10.147",
+    "axios-mock-adapter": "^2.0.0",
+    "mock-jwks": "^3.2.2",
+    "nock": "^14.0.0"
+  }
+}

--- a/packages/prescriptionDetailsLambda/src/handler.ts
+++ b/packages/prescriptionDetailsLambda/src/handler.ts
@@ -1,0 +1,10 @@
+import {APIGatewayProxyHandler} from "aws-lambda"
+
+export const handler: APIGatewayProxyHandler = async () => {
+  return {
+    statusCode: 200,
+    body: JSON.stringify({
+      message: "PrescriptionDetails Lambda function is working"
+    })
+  }
+}

--- a/packages/prescriptionDetailsLambda/src/handler.ts
+++ b/packages/prescriptionDetailsLambda/src/handler.ts
@@ -1,6 +1,15 @@
 import {APIGatewayProxyHandler} from "aws-lambda"
+import {Logger} from "@aws-lambda-powertools/logger"
+import {injectLambdaContext} from "@aws-lambda-powertools/logger/middleware"
+import middy from "@middy/core"
+import inputOutputLogger from "@middy/input-output-logger"
+import {MiddyErrorHandler} from "@cpt-ui-common/middyErrorHandler"
 
-export const handler: APIGatewayProxyHandler = async () => {
+const logger = new Logger({serviceName: "prescriptionDetails"})
+const errorResponseBody = {message: "A system error has occurred"}
+const middyErrorHandler = new MiddyErrorHandler(errorResponseBody)
+
+export const lambdaHandler: APIGatewayProxyHandler = async () => {
   return {
     statusCode: 200,
     body: JSON.stringify({
@@ -8,3 +17,14 @@ export const handler: APIGatewayProxyHandler = async () => {
     })
   }
 }
+
+export const handler = middy(lambdaHandler)
+  .use(injectLambdaContext(logger, {clearState: true}))
+  .use(
+    inputOutputLogger({
+      logger: (request) => {
+        logger.info(request)
+      }
+    })
+  )
+  .use(middyErrorHandler.errorHandler({logger: logger}))

--- a/packages/prescriptionDetailsLambda/src/handler.ts
+++ b/packages/prescriptionDetailsLambda/src/handler.ts
@@ -1,20 +1,38 @@
-import {APIGatewayProxyHandler} from "aws-lambda"
+import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda"
 import {Logger} from "@aws-lambda-powertools/logger"
 import {injectLambdaContext} from "@aws-lambda-powertools/logger/middleware"
 import middy from "@middy/core"
 import inputOutputLogger from "@middy/input-output-logger"
 import {MiddyErrorHandler} from "@cpt-ui-common/middyErrorHandler"
+import {mockPrescriptionDetails} from "./mockPrescriptionDetails"
 
 const logger = new Logger({serviceName: "prescriptionDetails"})
+const apigeePrescriptionsEndpoint = process.env["apigeePrescriptionsEndpoint"] as string
+
 const errorResponseBody = {message: "A system error has occurred"}
 const middyErrorHandler = new MiddyErrorHandler(errorResponseBody)
 
-export const lambdaHandler: APIGatewayProxyHandler = async () => {
+export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+  // Attach request ID for tracing
+  logger.appendKeys({"apigw-request-id": event.requestContext?.requestId})
+  logger.info("Lambda handler invoked", {event})
+
+  let prescriptionId: string | undefined
+
+  // Fetch prescription data from Apigee API
+  prescriptionId = event.pathParameters?.prescriptionId || "defaultId"
+
+  logger.info("Fetching prescription data from Apigee", {prescriptionId})
+
+  logger.info("Successfully fetched prescription details from Apigee", {
+    apigeePrescriptionsEndpoint,
+    prescriptionId,
+    data: JSON.stringify(mockPrescriptionDetails)
+  })
+
   return {
     statusCode: 200,
-    body: JSON.stringify({
-      message: "PrescriptionDetails Lambda function is working"
-    })
+    body: JSON.stringify(mockPrescriptionDetails)
   }
 }
 

--- a/packages/prescriptionDetailsLambda/src/mockPrescriptionDetails.ts
+++ b/packages/prescriptionDetailsLambda/src/mockPrescriptionDetails.ts
@@ -1,0 +1,196 @@
+export const mockPrescriptionDetails = {
+  "resourceType": "Bundle",
+  "type": "collection",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "RequestGroup",
+        "intent": "proposal",
+        "status": "active",
+        "groupIdentifier": {
+          "system": "https://fhir.nhs.uk/Id/prescription-group",
+          "value": "C0C757-A83008-C2D93O"
+        },
+        "identifier": [
+          {
+            "system": "https://fhir.nhs.uk/Id/prescription-order-number",
+            "value": "1"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/CodeSystem/prescription-type",
+              "code": "0101",
+              "display": "Prescription Type"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "C0C757-A83008-C2D93O",
+        "intent": "order",
+        "subject": {
+          "reference": "Patient12345"
+        },
+        "status": "active",
+        "medicationCodeableConcept": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/CodeSystem/medication",
+              "code": "Amoxicillin 250mg capsules",
+              "display": "Amoxicillin 250mg capsules"
+            }
+          ]
+        },
+        "dispenseRequest": {
+          "quantity": {
+            "value": 20
+          }
+        },
+        "dosageInstruction": [
+          {
+            "text": "2 times a day for 10 days"
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "C0C757-A83008-C2D93O",
+        "intent": "order",
+        "subject": {
+          "reference": "Patient12345"
+        },
+        "status": "active",
+        "medicationCodeableConcept": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/CodeSystem/medication",
+              "code": "Co-codamol 30mg/500mg tablets",
+              "display": "Co-codamol 30mg/500mg tablets"
+            }
+          ]
+        },
+        "dispenseRequest": {
+          "quantity": {
+            "value": 20
+          }
+        },
+        "dosageInstruction": [
+          {
+            "text": "2 times a day for 10 days"
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "C0C757-A83008-C2D93O",
+        "intent": "order",
+        "subject": {
+          "reference": "Patient12345"
+        },
+        "status": "active",
+        "medicationCodeableConcept": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/CodeSystem/medication",
+              "code": "Pseudoephedrine hydrochloride 60mg tablets",
+              "display": "Pseudoephedrine hydrochloride 60mg tablets"
+            }
+          ]
+        },
+        "dispenseRequest": {
+          "quantity": {
+            "value": 30
+          }
+        },
+        "dosageInstruction": [
+          {
+            "text": "3 times a day for 10 days"
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "C0C757-A83008-C2D93O",
+        "intent": "order",
+        "subject": {
+          "reference": "Patient12345"
+        },
+        "status": "active",
+        "medicationCodeableConcept": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/CodeSystem/medication",
+              "code": "Azithromycin 250mg capsules",
+              "display": "Azithromycin 250mg capsules"
+            }
+          ]
+        },
+        "dispenseRequest": {
+          "quantity": {
+            "value": 30
+          }
+        },
+        "dosageInstruction": [
+          {
+            "text": "3 times a day for 10 days"
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Task",
+        "id": "C0C757-A83008-C2D93O",
+        "status": "completed",
+        "intent": "order",
+        "groupIdentifier": {
+          "system": "https://fhir.nhs.uk/Id/task-group",
+          "value": "Release Request successful"
+        },
+        "authoredOn": "20250203141019",
+        "owner": {
+          "identifier": {
+            "system": "https://fhir.nhs.uk/Id/pharmacy",
+            "value": "VNFKT"
+          }
+        },
+        "businessStatus": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/CodeSystem/task-status",
+              "code": "0002",
+              "display": "Task Status"
+            }
+          ]
+        },
+        "output": [
+          {
+            "type": {
+              "coding": [
+                {
+                  "system": "https://fhir.nhs.uk/CodeSystem/task-output",
+                  "code": "medication-dispense",
+                  "display": "Medication Dispense Reference"
+                }
+              ]
+            },
+            "valueReference": {
+              "reference": "MedicationDispense/C0C757-A83008-C2D93O"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/prescriptionDetailsLambda/tsconfig.json
+++ b/packages/prescriptionDetailsLambda/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.defaults.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "lib"
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules"],
+  "references": [
+    {
+      "path": "../common/authFunctions"
+    },
+    {
+      "path": "../common/middyErrorHandler"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

🎫 [AEA-4752](https://nhsd-jira.digital.nhs.uk/browse/AEA-4752) GET /prescriptionDetails

- :sparkles: New Feature

### Details


- To represent the prescribedFrom field whether the prescription is from England or Wales the following should be applied:
  - If the starting two digits are either 01 or 1x this has come from England
  - If the starting two digits are either 02 or 2x this has come from Wales
  - If the starting two digits are any other number type, this will come through as 'Unknown'
  - For more detail see this page: https://simplifier.net/packages/uk.nhsdigital.r4.test/2.10.1-prerelease/files/2695691 

- Calls Directory of Healtcare Services (DoHS) can be done in one single call with multiple ODS Codes
  - This will implement the DoHS API integration 
    - This should be done as a common re-usable code for later/other endpoints

  - The documentation on DoHS can be found here: https://digital.nhs.uk/developer/api-catalogue/directory-of-healthcare-services/version-3
  - Example search: https://internal-dev.api.service.nhs.uk/service-search-api/?api-version=3&$filter=ODSCode eq 'Y02494' or ODSCode eq 'V017953'

- If there the data returned from the CPTS API is incomplete this must return an error