### PR TITLE
Fix: [AEA-0000] - fixes incorrect navigation bug

### DIFF
--- a/packages/cpt-ui/src/components/EpsRoleSelectionPage.tsx
+++ b/packages/cpt-ui/src/components/EpsRoleSelectionPage.tsx
@@ -1,11 +1,12 @@
 import React, { useState, useEffect, } from "react"
 import { useNavigate } from "react-router-dom"
-import { Container, Col, Row, Details, Table, ErrorSummary, Button, InsetText } from "nhsuk-react-components"
+import { Container, Col, Row, Details, Table, ErrorSummary, InsetText } from "nhsuk-react-components"
 
 import { useAccess } from "@/context/AccessProvider"
 import EpsCard from "@/components/EpsCard"
 import EpsSpinner from "@/components/EpsSpinner"
 import { RoleDetails } from "@/types/TrackerUserInfoTypes"
+import { Button } from "./ReactRouterButton"
 
 // This is passed to the EPS card component.
 export type RolesWithAccessProps = {
@@ -193,7 +194,12 @@ export default function RoleSelectionPage({
                     ></p>
                   )}
                 </InsetText>
-                <Button href={confirmButton.link}>{confirmButton.text}</Button>
+                <Button
+                  to={confirmButton.link}
+                  data-testid="confirm-and-continue"
+                >
+                  {confirmButton.text}
+                </Button>
                 <p>{alternativeMessage}</p>
               </section>
             )}

--- a/packages/cpt-ui/src/components/ReactRouterButton.tsx
+++ b/packages/cpt-ui/src/components/ReactRouterButton.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import { Button as NHSButton } from 'nhsuk-react-components'
+import { useNavigate } from 'react-router-dom'
+
+interface ReactRouterButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+    /** The text content of the button */
+    children: React.ReactNode
+    /** Optional route to navigate to when clicked */
+    to?: string
+    /** Optional click handler for custom behavior */
+    onClick?: (event: React.MouseEvent<HTMLButtonElement> | React.KeyboardEvent<HTMLButtonElement>) => void
+    /** Optional additional className */
+    className?: string
+    /** Data test id for testing */
+    'data-testid'?: string
+}
+
+
+export const Button: React.FC<ReactRouterButtonProps> = ({
+    children,
+    to,
+    disabled = false,
+    onClick,
+    className = '',
+    'data-testid': testId,
+    ...props
+}) => {
+    const navigate = useNavigate()
+
+    const handleClick = (event: React.MouseEvent<HTMLButtonElement> | React.KeyboardEvent<HTMLButtonElement>) => {
+        if (to) {
+            event.preventDefault()
+            const absolutePath = to.startsWith('/') ? to : `/${to}`
+            navigate(absolutePath)
+            return
+        }
+
+        onClick?.(event)
+    }
+
+    return (
+        <NHSButton
+            onClick={handleClick}
+            className={`${className}`}
+            data-testid={testId}
+            {...props}
+        >
+            {children}
+        </NHSButton>
+    )
+
+}

--- a/packages/cpt-ui/src/pages/YourSelectedRolePage.tsx
+++ b/packages/cpt-ui/src/pages/YourSelectedRolePage.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from "react"
 
-import { Container, Col, Row, Button, Table } from "nhsuk-react-components"
+import { Container, Col, Row, Table } from "nhsuk-react-components"
 import { useNavigate, Link } from "react-router-dom"
 
 import { YOUR_SELECTED_ROLE_STRINGS } from "@/constants/ui-strings/YourSelectedRoleStrings"
 import { useAccess } from "@/context/AccessProvider"
+import { Button } from "@/components/ReactRouterButton"
 
 export default function YourSelectedRolePage() {
   const navigate = useNavigate()
@@ -27,12 +28,6 @@ export default function YourSelectedRolePage() {
     setOrgName(selectedRole.org_name || YOUR_SELECTED_ROLE_STRINGS.noOrgName)
     setOdsCode(selectedRole.org_code || YOUR_SELECTED_ROLE_STRINGS.noODSCode)
   }, [selectedRole])
-
-  const handleRedirect = async (e: React.MouseEvent | React.KeyboardEvent) => {
-    // Naked href don't respect the router, so this overrides that
-    e.preventDefault()
-    navigate("/searchforaprescription")
-  }
 
   const {
     heading,
@@ -105,7 +100,7 @@ export default function YourSelectedRolePage() {
         <Row>
           <Col width="two-thirds">
             <Button
-              onClick={handleRedirect}
+              to="/searchforaprescription"
               data-testid="confirm-and-continue"
             >
               {confirmButtonText}


### PR DESCRIPTION
## Summary

Fixes navigation bug that was introduced during the NextJS to Vite + React + React Router migration. The bug was caused by not using the navigate API when the button was clicked, instead we were defaulting to the vanilla functionality of the NHS Design System Button when href tag is provided.

- :sparkles: Creates a new button component wrapping react router functionality around the NHS Design System Button
