### PR TITLE
Fix: [AEA-0000] - change subscription filter to be an L1 construct #3218 

### DIFF
--- a/packages/cdk/resources/LambdaFunction.ts
+++ b/packages/cdk/resources/LambdaFunction.ts
@@ -9,13 +9,7 @@ import {NodejsFunction} from "aws-cdk-lib/aws-lambda-nodejs"
 import {CfnFunction, LayerVersion} from "aws-cdk-lib/aws-lambda"
 import {Fn, RemovalPolicy} from "aws-cdk-lib"
 import {Key} from "aws-cdk-lib/aws-kms"
-import {
-  LogGroup,
-  CfnLogGroup,
-  SubscriptionFilter,
-  FilterPattern
-} from "aws-cdk-lib/aws-logs"
-import {KinesisDestination} from "aws-cdk-lib/aws-logs-destinations"
+import {LogGroup, CfnLogGroup, CfnSubscriptionFilter} from "aws-cdk-lib/aws-logs"
 import {Stream} from "aws-cdk-lib/aws-kinesis"
 import {Construct} from "constructs"
 
@@ -103,12 +97,11 @@ export class LambdaFunction extends Construct {
         })]
     })
 
-    new SubscriptionFilter(this, "LambdaLogsSplunkSubscriptionFilter", {
-      logGroup: lambdaLogGroup,
-      filterPattern: FilterPattern.allTerms(),
-      destination: new KinesisDestination(splunkDeliveryStream, {
-        role: splunkSubscriptionFilterRole
-      })
+    new CfnSubscriptionFilter(this, "CoordinatorSplunkSubscriptionFilter", {
+      destinationArn: splunkDeliveryStream.streamArn,
+      filterPattern: "",
+      logGroupName: lambdaLogGroup.logGroupName,
+      roleArn: splunkSubscriptionFilterRole.roleArn
     })
 
     const lambdaRole = new Role(this, "LambdaRole", {

--- a/packages/cdk/resources/RestApiGateway.ts
+++ b/packages/cdk/resources/RestApiGateway.ts
@@ -10,8 +10,7 @@ import {
 import {IRole, Role, ServicePrincipal} from "aws-cdk-lib/aws-iam"
 import {IStream} from "aws-cdk-lib/aws-kinesis"
 import {IKey} from "aws-cdk-lib/aws-kms"
-import {FilterPattern, LogGroup, SubscriptionFilter} from "aws-cdk-lib/aws-logs"
-import {KinesisDestination} from "aws-cdk-lib/aws-logs-destinations"
+import {CfnSubscriptionFilter, LogGroup} from "aws-cdk-lib/aws-logs"
 import {Construct} from "constructs"
 import {accessLogFormat} from "./RestApiGateway/accessLogFormat"
 import {IUserPool} from "aws-cdk-lib/aws-cognito"
@@ -50,12 +49,11 @@ export class RestApiGateway extends Construct {
       removalPolicy: RemovalPolicy.DESTROY
     })
 
-    new SubscriptionFilter(this, "ApiGatewayAccessLogsSplunkSubscriptionFilter", {
-      logGroup: apiGatewayAccessLogGroup,
-      filterPattern: FilterPattern.allTerms(),
-      destination: new KinesisDestination(props.splunkDeliveryStream, {
-        role: props.splunkSubscriptionFilterRole
-      })
+    new CfnSubscriptionFilter(this, "CoordinatorSplunkSubscriptionFilter", {
+      destinationArn: props.splunkDeliveryStream.streamArn,
+      filterPattern: "",
+      logGroupName: apiGatewayAccessLogGroup.logGroupName,
+      roleArn: props.splunkSubscriptionFilterRole.roleArn
     })
 
     const apiGateway = new RestApi(this, "ApiGateway", {


### PR DESCRIPTION
## Summary

- Routine Change

### Details

- change the subscription filter to be an L1 construct so that it does not create an extra policy