### PR TITLE
New: [AEA-4802] - Create site description cards

### DIFF
--- a/packages/cpt-ui/src/App.tsx
+++ b/packages/cpt-ui/src/App.tsx
@@ -13,6 +13,7 @@ import YourSelectedRolePage from "@/pages/YourSelectedRolePage"
 import NotFoundPage from "@/pages/NotFoundPage"
 import PrescriptionListPage from "@/pages/PrescriptionListPage"
 import PrescriptionNotFoundPage from "@/pages/PrescriptionNotFoundPage"
+import PrescriptionDetailsPage from "@/pages/PrescriptionDetailsPage"
 
 import {FRONTEND_PATHS} from "@/constants/environment"
 
@@ -50,6 +51,10 @@ export default function App() {
               <Route
                 path={FRONTEND_PATHS.PRESCRIPTION_NOT_FOUND}
                 element={<PrescriptionNotFoundPage />}
+              />
+              <Route
+                path={FRONTEND_PATHS.PRESCRIPTION_DETAILS_PAGE}
+                element={<PrescriptionDetailsPage />}
               />
             </Route>
           </Routes>

--- a/packages/cpt-ui/src/components/siteCards/SiteCards.tsx
+++ b/packages/cpt-ui/src/components/siteCards/SiteCards.tsx
@@ -2,7 +2,8 @@ import {Card, Col, Row} from "nhsuk-react-components"
 
 export interface SiteCardProps {
     heading: string
-    org: string
+    orgName: string
+    orgOds: string
     address: string
     contact: string
     prescribedFrom?: string
@@ -16,7 +17,8 @@ export interface SiteCardsProps {
 
 export function SiteCard({
   heading,
-  org,
+  orgName,
+  orgOds,
   address,
   contact,
   prescribedFrom
@@ -29,7 +31,7 @@ export function SiteCard({
           <p className="nhsuk-u-margin-bottom-2">
             <strong>{heading}</strong>
             <br />
-            {org}
+            {`${orgName} (ODS ${orgOds})`}
           </p>
           <p className={"nhsuk-u-margin-bottom-2"}>
             {address}

--- a/packages/cpt-ui/src/components/siteCards/SiteCards.tsx
+++ b/packages/cpt-ui/src/components/siteCards/SiteCards.tsx
@@ -1,0 +1,73 @@
+import {Card, Col, Row} from "nhsuk-react-components"
+
+export interface SiteCardProps {
+    heading: string
+    org: string
+    address: string
+    contact: string
+    prescribedFrom?: string
+}
+
+export interface SiteCardsProps {
+  prescriber: Omit<SiteCardProps, "heading">
+  dispenser?: Omit<SiteCardProps, "heading">
+  nominatedDispenser?: Omit<SiteCardProps, "heading">
+}
+
+export function SiteCard({
+  heading,
+  org,
+  address,
+  contact,
+  prescribedFrom
+}: SiteCardProps) {
+
+  return (
+    <Card cardType="primary" clickable={false}>
+      <Card.Content>
+        <Card.Description>
+          <p className="nhsuk-u-margin-bottom-2">
+            <strong>{heading}</strong>
+            <br />
+            {org}
+          </p>
+          <p className={"nhsuk-u-margin-bottom-2"}>
+            {address}
+          </p>
+          <p className="nhsuk-u-margin-bottom-2">
+            <strong>Contact Details</strong>
+            <br />
+            {contact}
+          </p>
+          {prescribedFrom &&
+                  <p className="nhsuk-u-margin-bottom-1">
+                    <strong>Prescribed from</strong>
+                    <br />
+                    {prescribedFrom}
+                  </p>
+          }
+        </Card.Description>
+      </Card.Content>
+    </Card>
+  )
+}
+
+export function SiteCards({
+  prescriber,
+  dispenser,
+  nominatedDispenser
+}: SiteCardsProps) {
+  return (
+    <Row>
+      <Col width="one-third">
+        <SiteCard heading={"Prescriber"} {...prescriber} />
+        { dispenser &&
+          <SiteCard heading={"Dispenser"} {...dispenser} />
+        }
+        {nominatedDispenser &&
+          <SiteCard heading={"Nominated Dispenser"} {...nominatedDispenser} />
+        }
+      </Col>
+    </Row>
+  )
+}

--- a/packages/cpt-ui/src/constants/environment.ts
+++ b/packages/cpt-ui/src/constants/environment.ts
@@ -55,7 +55,8 @@ export const FRONTEND_PATHS = {
   CHANGE_YOUR_ROLE: "/change-your-role",
   SEARCH_BY_PRESCRIPTION_ID: "/search-by-prescription-id",
   SEARCH_BY_NHS_NUMBER: "/search-by-nhs-number",
-  SEARCH_BY_BASIC_DETAILS: "/search-by-basic-details"
+  SEARCH_BY_BASIC_DETAILS: "/search-by-basic-details",
+  PRESCRIPTION_DETAILS_PAGE: "/prescription-details"
 }
 
 // This needs to be provided in backend requests as a header

--- a/packages/cpt-ui/src/context/PatientDetailsProvider.tsx
+++ b/packages/cpt-ui/src/context/PatientDetailsProvider.tsx
@@ -9,6 +9,7 @@ import {useLocation} from "react-router-dom"
 
 import {PatientDetails} from "@cpt-ui-common/common-types"
 import {normalizePath} from "@/helpers/utils"
+import {FRONTEND_PATHS} from "@/constants/environment"
 
 export type PatientDetailsContextType = {
     patientDetails: PatientDetails | undefined
@@ -33,8 +34,9 @@ export const PatientDetailsProvider = ({children}: { children: ReactNode }) => {
   useEffect(() => {
     // TODO: Ensure this is up to date as pages get implemented!
     const patientDetailsAllowedPaths = [
-      "/prescription-results"
+      "/prescription-results",
       // "/prescription-details",
+      FRONTEND_PATHS.PRESCRIPTION_DETAILS_PAGE
     ]
 
     const path = normalizePath(location.pathname)

--- a/packages/cpt-ui/src/pages/PrescriptionDetailsPage.tsx
+++ b/packages/cpt-ui/src/pages/PrescriptionDetailsPage.tsx
@@ -3,20 +3,23 @@ import {SiteCards} from "@/components/siteCards/SiteCards"
 export default function PrescriptionDetailsPage() {
   // Mock data, lifted from the prototype page.
   const prescriber = {
-    org: "Fiji surgery (ODS: FI05964)",
+    orgName: "Fiji surgery",
+    orgOds: "FI05964",
     address: "90 YARROW LANE, FINNSBURY, E45 T46",
     contact: "01232 231321",
     prescribedFrom: "England"
   }
 
   const dispenser = {
-    org: "Cohens chemist (ODS: FV519)",
+    orgName: "Cohens chemist",
+    orgOds: "FV519",
     address: "22 RUE LANE, CHISWICK, KT19 D12",
     contact: "01943 863158"
   }
 
   const nominatedDispenser = {
-    org: "Cohens chemist (ODS: FV519)",
+    orgName: "Cohens chemist",
+    orgOds: "FV519",
     address: "22 RUE LANE, CHISWICK, KT19 D12",
     contact: "01943 863158"
   }

--- a/packages/cpt-ui/src/pages/PrescriptionDetailsPage.tsx
+++ b/packages/cpt-ui/src/pages/PrescriptionDetailsPage.tsx
@@ -1,0 +1,34 @@
+import {SiteCards} from "@/components/siteCards/SiteCards"
+
+export default function PrescriptionDetailsPage() {
+  // Mock data, lifted from the prototype page.
+  const prescriber = {
+    org: "Fiji surgery (ODS: FI05964)",
+    address: "90 YARROW LANE, FINNSBURY, E45 T46",
+    contact: "01232 231321",
+    prescribedFrom: "England"
+  }
+
+  const dispenser = {
+    org: "Cohens chemist (ODS: FV519)",
+    address: "22 RUE LANE, CHISWICK, KT19 D12",
+    contact: "01943 863158"
+  }
+
+  const nominatedDispenser = {
+    org: "Cohens chemist (ODS: FV519)",
+    address: "22 RUE LANE, CHISWICK, KT19 D12",
+    contact: "01943 863158"
+  }
+
+  return (
+    // Temporary holding div to add padding. Not where this will actually be placed.
+    <div className={"nhsuk-u-margin-top-2 nhsuk-u-margin-left-2"}>
+      <SiteCards
+        prescriber={prescriber}
+        dispenser={dispenser}
+        nominatedDispenser={nominatedDispenser}
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Routine Change

### Details

This adds a single component, which is used to render site information. It has at least a Prescribing organisation, and optionally has a dispenser, and nominated dispenser cards.