### PR TITLE
Chore: [AEA-0000] - Update the backlink behaviour on the prescription not found page

### DIFF
--- a/packages/cpt-ui/src/components/prescriptionSearch/PrescriptionIdSearch.tsx
+++ b/packages/cpt-ui/src/components/prescriptionSearch/PrescriptionIdSearch.tsx
@@ -1,5 +1,5 @@
 import React, {useState, useEffect, useRef} from "react"
-import {useNavigate} from "react-router-dom"
+import {useNavigate, useSearchParams} from "react-router-dom"
 
 import {
   Container,
@@ -25,6 +25,7 @@ const normalizePrescriptionId = (raw: string): string => {
 
 export default function PrescriptionIdSearch() {
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
   const errorRef = useRef<HTMLDivElement | null>(null)
 
   const [prescriptionId, setPrescriptionId] = useState<string>("")
@@ -36,6 +37,8 @@ export default function PrescriptionIdSearch() {
   useEffect(() => {
     const input = document.querySelector<HTMLInputElement>("#presc-id-input")
     input?.focus()
+
+    setPrescriptionId(searchParams.get("prescriptionId") || "")
   }, [])
 
   // Focus error box when error appears

--- a/packages/cpt-ui/src/pages/PrescriptionListPage.tsx
+++ b/packages/cpt-ui/src/pages/PrescriptionListPage.tsx
@@ -175,7 +175,16 @@ export default function PrescriptionListPage() {
 
       if (!searchResults) {
         console.error("No search results were returned", searchResults)
-        navigate(FRONTEND_PATHS.PRESCRIPTION_NOT_FOUND)
+
+        // Send the search method and parameters to the not found page
+        let searchType
+        if (hasPrescriptionId) {
+          searchType = "prescriptionId"
+        } else if (hasNhsNumber) {
+          searchType = "nhsNumber"
+        }
+
+        navigate(FRONTEND_PATHS.PRESCRIPTION_NOT_FOUND + "?" + queryParams.toString() + `&searchType=${searchType}`)
         return
       }
 
@@ -185,7 +194,7 @@ export default function PrescriptionListPage() {
         && searchResults.futurePrescriptions.length === 0
       ) {
         console.error("A patient was returned, but they do not have any prescriptions.", searchResults)
-        navigate(FRONTEND_PATHS.PRESCRIPTION_NOT_FOUND)
+        navigate(FRONTEND_PATHS.PRESCRIPTION_NOT_FOUND + "?" + queryParams.toString())
       }
 
       setCurrentPrescriptions(searchResults.currentPrescriptions)

--- a/packages/cpt-ui/src/pages/PrescriptionNotFoundPage.tsx
+++ b/packages/cpt-ui/src/pages/PrescriptionNotFoundPage.tsx
@@ -10,13 +10,27 @@ export default function PrescriptionNotFoundPage() {
 
   // Map searchType to the correct back link URL
   const getBackLinkUrl = () => {
+
+    // Preserve any search terms
+    const params = searchParams
+      .entries()
+      .filter(
+        (entry) => {
+          return (entry[0] !== "searchType")
+        }
+      )
+      .toArray()
+    const newQueryString = new URLSearchParams(params)
+
+    console.info("Search type", searchType)
+
     switch (searchType) {
-      case "PrescriptionIdSearch":
-        return FRONTEND_PATHS.SEARCH_BY_PRESCRIPTION_ID
-      case "NhsNumberSearch":
-        return FRONTEND_PATHS.SEARCH_BY_NHS_NUMBER
-      case "BasicDetailsSearch":
-        return FRONTEND_PATHS.SEARCH_BY_BASIC_DETAILS
+      case "prescriptionId":
+        return FRONTEND_PATHS.SEARCH_BY_PRESCRIPTION_ID + "?" + newQueryString.toString()
+      case "nhsNumber":
+        return FRONTEND_PATHS.SEARCH_BY_NHS_NUMBER + "?" + newQueryString.toString()
+      case "basicDetails":
+        return FRONTEND_PATHS.SEARCH_BY_BASIC_DETAILS + "?" + newQueryString.toString()
       default:
         // Default fallback if no searchType is provided
         return FRONTEND_PATHS.SEARCH_BY_PRESCRIPTION_ID


### PR DESCRIPTION
## Summary

- Routine Change

### Details

The prescription not found page now accepts arbitrary query parameters, which are added to the backlink href. This can then be picked up by the search forms, and used to populate the fields automatically if we want. 

Note that in order to bypass this behaviour, all you need to do is NOT pass the query parameters, and we will see the old behaviour of losing and search values.