### PR TITLE
Update: [AEA-4791] - Update the Prescription not found page

### DIFF
--- a/scripts/run_regression_tests.py
+++ b/scripts/run_regression_tests.py
@@ -13,7 +13,7 @@ import time
 from requests.auth import HTTPBasicAuth
 
 # This should be set to a known good version of regression test repo
-REGRESSION_TESTS_REPO_TAG = "v2.34.2"
+REGRESSION_TESTS_REPO_TAG = "AEA-4791-update-prescription-not-found-page"
 
 GITHUB_API_URL = "https://api.github.com/repos/NHSDigital/electronic-prescription-service-api-regression-tests/actions"
 GITHUB_RUN_URL = "https://github.com/NHSDigital/electronic-prescription-service-api-regression-tests/actions/runs"


### PR DESCRIPTION
## Summary

🎫 [AEA-4791](https://nhsd-jira.digital.nhs.uk/browse/AEA-4791) Update the Prescription not found page
🧪 Regression Tests: https://github.com/NHSDigital/electronic-prescription-service-api-regression-tests/pull/341

- Routine Change

### Details

If there has been a search with a correctly formatted NHS Number or Prescription ID but there has been no result returned from it, it should return the following page of 'Prescription not found' 
This pull request implements the 'Patient not found' update