### PR TITLE
Chore: AEA-0000 -Modify devcontainer to support Apple Silicon

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,7 @@
 FROM mcr.microsoft.com/devcontainers/base:ubuntu
 
+RUN if [ "$(uname -m)" != "aarch64" ]; then dpkg --add-architecture amd64; fi
+
 RUN apt-get update \
     && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y dist-upgrade \
@@ -9,7 +11,7 @@ RUN apt-get update \
     jq apt-transport-https ca-certificates gnupg-agent \
     software-properties-common bash-completion python3-pip make libbz2-dev \
     libreadline-dev libsqlite3-dev wget llvm libncurses5-dev libncursesw5-dev \
-    xz-utils tk-dev liblzma-dev netcat libyaml-dev
+    xz-utils tk-dev liblzma-dev netcat-traditional libyaml-dev
 
 # install aws stuff
 RUN wget -O /tmp/awscliv2.zip "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" && \


### PR DESCRIPTION
## Summary

- Routine Change

### Details

Adjust the Dockerfile to support Apple Silicon users by checking host system architecture and defining which architecture packages should install.
Additionally more acutely define which netcat version to use, to ensure it has a release candidate for arm64 architectures.
