### PR TITLE
Fix: [AEA-5450] -new header to not store cache to the 3 endpoints

### DIFF
--- a/packages/patientSearchLambda/src/handler.ts
+++ b/packages/patientSearchLambda/src/handler.ts
@@ -12,11 +12,21 @@ export const INTERNAL_ERROR_RESPONSE_BODY = {
   message: "A system error has occurred"
 }
 
+// const code = (statusCode: number) => ({
+//   body: (body: object) => ({
+//     statusCode,
+//     body: JSON.stringify(body),
+//     headers: headerUtils.formatHeaders({"Content-Type": "application/json"})
+//   })
+// })
 const code = (statusCode: number) => ({
   body: (body: object) => ({
     statusCode,
     body: JSON.stringify(body),
-    headers: headerUtils.formatHeaders({"Content-Type": "application/json"})
+    headers: headerUtils.formatHeaders({
+      "Content-Type": "application/json",
+      "Cache-Control": "no-store"
+    })
   })
 })
 

--- a/packages/patientSearchLambda/src/handler.ts
+++ b/packages/patientSearchLambda/src/handler.ts
@@ -12,13 +12,6 @@ export const INTERNAL_ERROR_RESPONSE_BODY = {
   message: "A system error has occurred"
 }
 
-// const code = (statusCode: number) => ({
-//   body: (body: object) => ({
-//     statusCode,
-//     body: JSON.stringify(body),
-//     headers: headerUtils.formatHeaders({"Content-Type": "application/json"})
-//   })
-// })
 const code = (statusCode: number) => ({
   body: (body: object) => ({
     statusCode,

--- a/packages/prescriptionDetailsLambda/src/services/prescriptionService.ts
+++ b/packages/prescriptionDetailsLambda/src/services/prescriptionService.ts
@@ -156,11 +156,6 @@ export async function processPrescriptionRequest(
     try {
       const mergedResponse = mergePrescriptionDetails(apigeeResponse.data, doHSData)
 
-      // return {
-      //   statusCode: 200,
-      //   body: JSON.stringify(mergedResponse),
-      //   headers: formatHeaders(apigeeResponse.headers)
-      // }
       const responseHeaders = {
         "Content-Type": "application/json",
         "Cache-Control": "no-store",

--- a/packages/prescriptionDetailsLambda/src/services/prescriptionService.ts
+++ b/packages/prescriptionDetailsLambda/src/services/prescriptionService.ts
@@ -156,10 +156,21 @@ export async function processPrescriptionRequest(
     try {
       const mergedResponse = mergePrescriptionDetails(apigeeResponse.data, doHSData)
 
+      // return {
+      //   statusCode: 200,
+      //   body: JSON.stringify(mergedResponse),
+      //   headers: formatHeaders(apigeeResponse.headers)
+      // }
+      const responseHeaders = {
+        "Content-Type": "application/json",
+        "Cache-Control": "no-store",
+        ...apigeeResponse.headers as { [key: string]: string }
+      }
+
       return {
         statusCode: 200,
         body: JSON.stringify(mergedResponse),
-        headers: formatHeaders(apigeeResponse.headers)
+        headers: formatHeaders(responseHeaders)
       }
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     } catch (error) {

--- a/packages/prescriptionListLambda/src/handler.ts
+++ b/packages/prescriptionListLambda/src/handler.ts
@@ -91,7 +91,6 @@ const errorResponseBody = {
   message: "A system error has occurred"
 }
 
-// const RESPONSE_HEADERS = {"Content-Type": "application/json"}
 const RESPONSE_HEADERS = {
   "Content-Type": "application/json",
   "Cache-Control": "no-store"

--- a/packages/prescriptionListLambda/src/handler.ts
+++ b/packages/prescriptionListLambda/src/handler.ts
@@ -91,7 +91,11 @@ const errorResponseBody = {
   message: "A system error has occurred"
 }
 
-const RESPONSE_HEADERS = {"Content-Type": "application/json"}
+// const RESPONSE_HEADERS = {"Content-Type": "application/json"}
+const RESPONSE_HEADERS = {
+  "Content-Type": "application/json",
+  "Cache-Control": "no-store"
+}
 
 // Middleware error handler
 const middyErrorHandler = new MiddyErrorHandler(errorResponseBody)


### PR DESCRIPTION
## Summary

added header to not cache sensitive data returned from the api


- :robot: Operational or Infrastructure Change