### PR TITLE
Fix: [AEA-5480] - added new accepted activity code and confirmed it with test

### DIFF
--- a/packages/common/dynamoFunctions/src/userUtils.ts
+++ b/packages/common/dynamoFunctions/src/userUtils.ts
@@ -88,7 +88,7 @@ export const extractRoleInformation = (
   const rolesWithAccess: Array<RoleDetails> = []
   const rolesWithoutAccess: Array<RoleDetails> = []
   let currentlySelectedRole: RoleDetails | undefined = undefined
-  const accepted_access_codes = ["B0570", "B0278"]
+  const accepted_access_codes = ["B0570", "B0278", "B0401"]
 
   // Extract user details
   const userDetails: UserDetails = {

--- a/packages/common/dynamoFunctions/tests/userUtils.test.ts
+++ b/packages/common/dynamoFunctions/tests/userUtils.test.ts
@@ -167,6 +167,14 @@ describe("extractRoleInformation", () => {
           activity_codes: ["B0278"] // Also has access
         },
         {
+          org_code: "ORG2",
+          person_orgid: "PORG2",
+          person_roleid: "ROLE2",
+          role_code: "RC3",
+          role_name: "User Role",
+          activity_codes: ["B0401"] // Also has access
+        },
+        {
           org_code: "ORG3",
           person_orgid: "PORG3",
           person_roleid: "ROLE3",
@@ -194,8 +202,8 @@ describe("extractRoleInformation", () => {
     const selectedRoleId = ""
     const result = extractRoleInformation(mockUserInfo, selectedRoleId, mockLogger as Logger)
 
-    // Verify roles with access (should include both B0570 and B0278)
-    expect(result.roles_with_access).toHaveLength(2)
+    // Verify roles with access (should include B0570, B0278 and B0401)
+    expect(result.roles_with_access).toHaveLength(3)
     expect(result.roles_without_access).toHaveLength(1)
   })
 


### PR DESCRIPTION
## Summary
As part of the decision log: [D178 - Allowing administrative users working in healthcare access to the prescription tracker - Electronic prescription service (EPS) - CDT Confluence](https://nhsd-confluence.digital.nhs.uk/spaces/APIMC/pages/910442927/D178+-+Allowing+administrative+users+working+in+healthcare+access+to+the+prescription+tracker) we have agreed that the B0401-View Patient Medication is an additional activity code which could be given by RAs to give access to users to the Prescription Tracker who aren't Clinical.

- Routine Change
