### PR TITLE
Fix: [AEA-5480] -cant cycle between tab headers when typing

### DIFF
--- a/packages/cpt-ui/src/components/EpsTabs.tsx
+++ b/packages/cpt-ui/src/components/EpsTabs.tsx
@@ -27,6 +27,15 @@ export default function EpsTabs({
 
   const navigate = useNavigate()
   const handleKeyDown = useCallback((event: KeyboardEvent) => {
+    const activeElement = document.activeElement
+
+    // Prevent tab switching if focus is in an input box
+    if (
+      activeElement &&
+      (activeElement.tagName === "INPUT" || activeElement.tagName === "TEXTAREA")
+    ) {
+      return
+    }
     const tabs = tabHeaderArray
     const currentTabIndex = tabs.findIndex(
       (tab) => tab.link.includes(activeTabPath)

--- a/packages/cpt-ui/src/components/prescriptionSearch/PrescriptionIdSearch.tsx
+++ b/packages/cpt-ui/src/components/prescriptionSearch/PrescriptionIdSearch.tsx
@@ -102,7 +102,7 @@ export default function PrescriptionIdSearch() {
               </ErrorSummary>
             )}
 
-            <FormGroup className={errorKey ? "nhsuk-form-group--error" : ""}>
+            <FormGroup data-testId="search-by-prescriptionid-box" className={errorKey ? "nhsuk-form-group--error" : ""}>
               <Label htmlFor="presc-id-input" id="presc-id-label">
                 <h2
                   className="nhsuk-heading-m nhsuk-u-margin-bottom-1 no-outline"

--- a/scripts/run_regression_tests.py
+++ b/scripts/run_regression_tests.py
@@ -13,7 +13,7 @@ import time
 from requests.auth import HTTPBasicAuth
 
 # This should be set to a known good version of regression test repo
-REGRESSION_TESTS_REPO_TAG = "v2.39.6"
+REGRESSION_TESTS_REPO_TAG = "aea-5480-dont-change-tabs-when-typing"
 
 GITHUB_API_URL = "https://api.github.com/repos/NHSDigital/electronic-prescription-service-api-regression-tests/actions"
 GITHUB_RUN_URL = "https://github.com/NHSDigital/electronic-prescription-service-api-regression-tests/actions/runs"


### PR DESCRIPTION
## Summary

When the cursor is inside a text field, using the left/right arrow keys is changing tabs and removing the entered text. This should instead be moving through the text in the field 

- Routine Change
