### PR TITLE
Fix: [AEA-5422] - Dispensed and Cancelled Prescriptions shown in wrong prescription list tab

### DIFF
--- a/packages/cpt-ui/__tests__/PrescriptionListTab.test.tsx
+++ b/packages/cpt-ui/__tests__/PrescriptionListTab.test.tsx
@@ -11,7 +11,7 @@ import {
 
 import {PrescriptionsListStrings} from "@/constants/ui-strings/PrescriptionListTabStrings"
 
-import {PrescriptionSummary, TreatmentType} from "@cpt-ui-common/common-types"
+import {PrescriptionStatus, PrescriptionSummary, TreatmentType} from "@cpt-ui-common/common-types"
 
 // This mock just displays the data. Nothing fancy!
 jest.mock("@/components/prescriptionList/PrescriptionsListTable", () => {
@@ -189,7 +189,8 @@ describe("PrescriptionsListTabs", () => {
   it("shows dispensed prescriptions in the Current prescriptions tab", () => {
     const mockDispensedPrescription: PrescriptionSummary = {
       prescriptionId: "MOCK-DISPENSED-TEST",
-      statusCode: "0006",
+      isDeleted: false,
+      statusCode: PrescriptionStatus.DISPENSED,
       issueDate: "2025-06-15",
       prescriptionTreatmentType: TreatmentType.REPEAT,
       issueNumber: 1,

--- a/packages/cpt-ui/__tests__/PrescriptionListTab.test.tsx
+++ b/packages/cpt-ui/__tests__/PrescriptionListTab.test.tsx
@@ -10,8 +10,10 @@ import {
 } from "react-router-dom"
 
 import {PrescriptionsListStrings} from "@/constants/ui-strings/PrescriptionListTabStrings"
+
 import {PrescriptionSummary, TreatmentType} from "@cpt-ui-common/common-types"
 
+// This mock just displays the data. Nothing fancy!
 jest.mock("@/components/prescriptionList/PrescriptionsListTable", () => {
   return function DummyPrescriptionsList({
     textContent,
@@ -118,62 +120,64 @@ describe("PrescriptionsListTabs", () => {
     }
   ]
 
-  describe("with default mock data", () => {
-    beforeEach(() => {
-      const page = (
-        <PrescriptionsListTabs
-          tabData={tabData}
-          currentPrescriptions={currentPrescriptions}
-          futurePrescriptions={futurePrescriptions}
-          pastPrescriptions={pastPrescriptions}
-        />
-      )
-      render(
-        <MemoryRouter>
-          <Routes>
-            <Route path="*" element={page} />
-          </Routes>
-        </MemoryRouter>
-      )
+  beforeEach(() => {
+    const page =
+      <PrescriptionsListTabs
+        tabData={tabData}
+        currentPrescriptions={currentPrescriptions}
+        futurePrescriptions={futurePrescriptions}
+        pastPrescriptions={pastPrescriptions}
+      />
+    render(
+      <MemoryRouter>
+        <Routes>
+          <Route path="*" element={page} />
+        </Routes>
+      </MemoryRouter>
+    )
+  })
+
+  it("renders tab headers", () => {
+    tabData.forEach((tab) => {
+      expect(
+        screen.getByText(tab.title)
+      ).toBeInTheDocument()
     })
+  })
 
-    it("renders tab headers", () => {
-      tabData.forEach((tab) => {
-        expect(screen.getByText(tab.title)).toBeInTheDocument()
-      })
-    })
+  it("displays the correct PrescriptionsList for the default active tab", () => {
+    // Click on nothing - should default to current prescriptions
+    const list = screen.getByTestId(`eps-tab-heading ${tabData[0].link}`)
+    expect(list).toHaveTextContent(tabData[0].title)
+    expect(screen.getByTestId("mock-prescription-data")).toHaveTextContent(
+      `Count: ${currentPrescriptions.length}`
+    )
+  })
 
-    it("displays the correct PrescriptionsList for the default active tab", () => {
-      const list = screen.getByTestId(`eps-tab-heading ${tabData[0].link}`)
-      expect(list).toHaveTextContent(tabData[0].title)
-      expect(screen.getByTestId("mock-prescription-data")).toHaveTextContent(
-        `Count: ${currentPrescriptions.length}`
-      )
-    })
+  it("switches to the future tab and displays correct content", async () => {
+    // Click on the "Future" tab
+    const futureTabHeader = screen.getByText("Future Prescriptions")
+    await userEvent.click(futureTabHeader)
 
-    it("switches to the future tab and displays correct content", async () => {
-      const futureTabHeader = screen.getByText("Future Prescriptions")
-      await userEvent.click(futureTabHeader)
+    expect(screen.getByTestId(`eps-tab-heading ${tabData[1].link}`)).toHaveTextContent(
+      tabData[1].title
+    )
+    expect(screen.getByTestId("mock-prescription-data")).toHaveTextContent(
+      `Count: ${futurePrescriptions.length}`
+    )
+  })
 
-      expect(screen.getByTestId(`eps-tab-heading ${tabData[1].link}`)).toHaveTextContent(
-        tabData[1].title
-      )
-      expect(screen.getByTestId("mock-prescription-data")).toHaveTextContent(
-        `Count: ${futurePrescriptions.length}`
-      )
-    })
+  it("switches to the past tab and displays correct content", async () => {
+    // Click on the "Past" tab
+    const pastTabHeader = screen.getByText("Past Prescriptions")
+    await userEvent.click(pastTabHeader)
 
-    it("switches to the past tab and displays correct content", async () => {
-      const pastTabHeader = screen.getByText("Past Prescriptions")
-      await userEvent.click(pastTabHeader)
-
-      expect(screen.getByTestId(`eps-tab-heading ${tabData[2].link}`)).toHaveTextContent(
-        tabData[2].title
-      )
-      expect(screen.getByTestId("mock-prescription-data")).toHaveTextContent(
-        `Count: ${pastPrescriptions.length}`
-      )
-    })
+    expect(screen.getByTestId(`eps-tab-heading ${tabData[2].link}`)).toHaveTextContent(
+      tabData[2].title
+    )
+    expect(screen.getByTestId("mock-prescription-data")).toHaveTextContent(
+      `Count: ${pastPrescriptions.length}`
+    )
   })
 
   it("shows dispensed prescriptions in the Current Prescriptions tab", () => {
@@ -207,6 +211,8 @@ describe("PrescriptionsListTabs", () => {
 
     const mockDataElements = screen.getAllByTestId("mock-prescription-data")
     expect(mockDataElements.some(el => el.textContent?.includes("Count: 1"))).toBe(true)
-    expect(screen.getByText("Current Prescriptions")).toBeInTheDocument()
+
+    const currentTabs = screen.getAllByText("Current Prescriptions")
+    expect(currentTabs.length).toBeGreaterThan(0)
   })
 })

--- a/packages/cpt-ui/__tests__/PrescriptionListTab.test.tsx
+++ b/packages/cpt-ui/__tests__/PrescriptionListTab.test.tsx
@@ -180,7 +180,7 @@ describe("PrescriptionsListTabs", () => {
     )
   })
 
-  it("shows dispensed prescriptions in the Current Prescriptions tab", () => {
+  it("shows dispensed prescriptions in the Current prescriptions tab", () => {
     const mockDispensedPrescription: PrescriptionSummary = {
       prescriptionId: "MOCK-DISPENSED-TEST",
       statusCode: "0006",

--- a/packages/prescriptionListLambda/src/utils/types.ts
+++ b/packages/prescriptionListLambda/src/utils/types.ts
@@ -8,7 +8,7 @@ export const STATUS_CATEGORY_MAP: Record<PrescriptionStatus, PrescriptionStatusC
   [PrescriptionStatus.WITH_DISPENSER_ACTIVE]: PrescriptionStatusCategories.CURRENT,
   [PrescriptionStatus.EXPIRED]: PrescriptionStatusCategories.PAST,
   [PrescriptionStatus.CANCELLED]: PrescriptionStatusCategories.PAST,
-  [PrescriptionStatus.DISPENSED]: PrescriptionStatusCategories.PAST,
+  [PrescriptionStatus.DISPENSED]: PrescriptionStatusCategories.CURRENT,
   [PrescriptionStatus.NOT_DISPENSED]: PrescriptionStatusCategories.PAST,
   [PrescriptionStatus.CLAIMED]: PrescriptionStatusCategories.PAST,
   [PrescriptionStatus.NO_CLAIMED]: PrescriptionStatusCategories.PAST,
@@ -51,10 +51,10 @@ export const statusCodeMap: Record<string, string> = {
 }
 
 export interface SearchParams {
-    prescriptionId?: string;
-    nhsNumber?: string;
-  }
+  prescriptionId?: string
+  nhsNumber?: string
+}
 
 export interface IntentMap {
-    [key: string]: RequestGroup["intent"]
-  }
+  [key: string]: RequestGroup["intent"]
+}


### PR DESCRIPTION
## Summary

🎫 [AEA-5422](https://nhsd-jira.digital.nhs.uk/browse/AEA-5422) Dispensed and Cancelled Prescriptions shown in wrong prescription list tab

- Routine Change

### Details

This pull request implements a fix for the issue where dispensed prescriptions were appearing in the 'Claimed and Expired' tab instead of the 'Current Prescriptions' tab on the Prescriptions List page.