### PR TITLE
Fix: [AEA-5417] - filter prescriped dispensed items

### DIFF
--- a/packages/prescriptionDetailsLambda/src/services/prescriptionService.ts
+++ b/packages/prescriptionDetailsLambda/src/services/prescriptionService.ts
@@ -154,7 +154,7 @@ export async function processPrescriptionRequest(
     })
 
     try {
-      const mergedResponse = mergePrescriptionDetails(apigeeResponse.data, doHSData)
+      const mergedResponse = mergePrescriptionDetails(apigeeResponse.data, doHSData, logger)
 
       const responseHeaders = {
         "Content-Type": "application/json",

--- a/packages/prescriptionDetailsLambda/src/utils/fhirMappers.ts
+++ b/packages/prescriptionDetailsLambda/src/utils/fhirMappers.ts
@@ -101,10 +101,10 @@ export const extractPatientDetails = (patient: Patient | undefined): Omit<Patien
  * Extracts prescribed items from FHIR MedicationRequest resources
  */
 export const extractPrescribedItems = (medicationRequests: Array<MedicationRequest>) => {
-
   return medicationRequests.map(request => {
     const pendingCancellationExt = findExtensionByKey(request.extension, "PENDING_CANCELLATION")
     const dispensingInfoExt = findExtensionByKey(request.extension, "DISPENSING_INFORMATION")
+
     const epsStatusCode = getCodeFromNestedExtension(dispensingInfoExt, "dispenseStatus") ?? "unknown"
 
     const quantityValue = request.dispenseRequest?.quantity?.value?.toString() ?? "Unknown"

--- a/packages/prescriptionDetailsLambda/src/utils/fhirMappers.ts
+++ b/packages/prescriptionDetailsLambda/src/utils/fhirMappers.ts
@@ -100,20 +100,16 @@ export const extractPatientDetails = (patient: Patient | undefined): Omit<Patien
 /**
  * Extracts prescribed items from FHIR MedicationRequest resources
  */
-export const extractPrescribedItems = (medicationRequests: Array<MedicationRequest>, dispensedItems: object) => {
+export const extractPrescribedItems = (medicationRequests: Array<MedicationRequest>) => {
 
   return medicationRequests.map(request => {
     const pendingCancellationExt = findExtensionByKey(request.extension, "PENDING_CANCELLATION")
     const dispensingInfoExt = findExtensionByKey(request.extension, "DISPENSING_INFORMATION")
-    const medicationRequestId = request.id
     const epsStatusCode = getCodeFromNestedExtension(dispensingInfoExt, "dispenseStatus") ?? "unknown"
 
     const quantityValue = request.dispenseRequest?.quantity?.value?.toString() ?? "Unknown"
     const quantityUnit = request.dispenseRequest?.quantity?.unit ?? ""
     const quantity = quantityUnit ? `${quantityValue} ${quantityUnit}` : quantityValue
-    //urn:uuid: to be removed from authorizingPrescriptionId
-
-    // const x = request.
 
     return {
       medicationName: request.medicationCodeableConcept?.text ??

--- a/packages/prescriptionDetailsLambda/src/utils/fhirMappers.ts
+++ b/packages/prescriptionDetailsLambda/src/utils/fhirMappers.ts
@@ -100,16 +100,20 @@ export const extractPatientDetails = (patient: Patient | undefined): Omit<Patien
 /**
  * Extracts prescribed items from FHIR MedicationRequest resources
  */
-export const extractPrescribedItems = (medicationRequests: Array<MedicationRequest>) => {
+export const extractPrescribedItems = (medicationRequests: Array<MedicationRequest>, dispensedItems: object) => {
+
   return medicationRequests.map(request => {
     const pendingCancellationExt = findExtensionByKey(request.extension, "PENDING_CANCELLATION")
     const dispensingInfoExt = findExtensionByKey(request.extension, "DISPENSING_INFORMATION")
-
+    const medicationRequestId = request.id
     const epsStatusCode = getCodeFromNestedExtension(dispensingInfoExt, "dispenseStatus") ?? "unknown"
 
     const quantityValue = request.dispenseRequest?.quantity?.value?.toString() ?? "Unknown"
     const quantityUnit = request.dispenseRequest?.quantity?.unit ?? ""
     const quantity = quantityUnit ? `${quantityValue} ${quantityUnit}` : quantityValue
+    //urn:uuid: to be removed from authorizingPrescriptionId
+
+    // const x = request.
 
     return {
       medicationName: request.medicationCodeableConcept?.text ??

--- a/packages/prescriptionDetailsLambda/src/utils/responseMapper.ts
+++ b/packages/prescriptionDetailsLambda/src/utils/responseMapper.ts
@@ -35,6 +35,7 @@ const extractDispensedItemsFromMedicationDispenses = (
   medicationDispenses: Array<MedicationDispense>,
   medicationRequests: Array<MedicationRequest>
 ): Array<{
+    authorizingPrescription: object | undefined
     medicationName: string
     quantity: string
     dosageInstructions: string
@@ -53,6 +54,8 @@ const extractDispensedItemsFromMedicationDispenses = (
     // Extract EPS status from Extension-EPS-TaskBusinessStatus (not nested)
     const businessStatusExt = findExtensionByKey(dispense.extension, "TASK_BUSINESS_STATUS")
     const epsStatusCode = businessStatusExt?.valueCoding?.code ?? "unknown"
+
+    const authorizingPrescription = dispense.authorizingPrescription
 
     // Extract notDispensedReason from extension
     const notDispensedReasonExt = findExtensionByKey(dispense.extension, "NON_DISPENSING_REASON")
@@ -114,6 +117,7 @@ const extractDispensedItemsFromMedicationDispenses = (
     }
 
     return {
+      authorizingPrescription,
       medicationName: dispensedMedicationName,
       quantity: dispensedQuantity,
       dosageInstructions: dispensedDosageInstructions,
@@ -336,8 +340,8 @@ export const mergePrescriptionDetails = (
 
   // extract and format all the data
   const patientDetails = extractPatientDetails(patient)
-  const prescribedItems = extractPrescribedItems(medicationRequests)
   const dispensedItems = extractDispensedItemsFromMedicationDispenses(medicationDispenses, medicationRequests)
+  const prescribedItems = extractPrescribedItems(medicationRequests, dispensedItems)
   const messageHistory = extractMessageHistory(requestGroup, doHSData, medicationDispenses)
 
   // TODO: extract NHS App status from dispensing information extension

--- a/packages/prescriptionDetailsLambda/tests/test_responseMapper.test.ts
+++ b/packages/prescriptionDetailsLambda/tests/test_responseMapper.test.ts
@@ -150,7 +150,7 @@ describe("mergePrescriptionDetails", () => {
             medicationCodeableConcept: {text: "Drug B"},
             quantity: {value: 20},
             dosageInstruction: [{text: "Take two daily"}],
-            status: "completed",
+            status: "in-progress",
             authorizingPrescription: [{
               reference: "MedicationRequest/med-req-1"
             }],
@@ -242,16 +242,7 @@ describe("mergePrescriptionDetails", () => {
     expect(result.prescriptionPendingCancellation).toBe(true)
 
     // Check prescribed items
-    expect(result.prescribedItems).toHaveLength(1)
-    expect(result.prescribedItems[0]).toEqual({
-      medicationName: "Drug A",
-      quantity: "20",
-      dosageInstructions: "Take two daily",
-      epsStatusCode: "0007",
-      nhsAppStatus: undefined,
-      itemPendingCancellation: false,
-      cancellationReason: null
-    })
+    expect(result.prescribedItems).toHaveLength(0)
 
     // Check dispensed items
     expect(result.dispensedItems).toHaveLength(1)
@@ -731,6 +722,7 @@ describe("mergePrescriptionDetails", () => {
         {
           resource: {
             resourceType: "MedicationRequest",
+            id: "med-req-x",
             medicationCodeableConcept: {text: "Drug X"},
             dispenseRequest: {quantity: {value: 10}},
             dosageInstruction: [{text: "Once daily"}],
@@ -789,9 +781,9 @@ describe("mergePrescriptionDetails", () => {
             id: "dispense-x",
             medicationCodeableConcept: {text: "Drug Z"},
             quantity: {value: 15},
-            status: "completed",
+            status: "in-progress",
             authorizingPrescription: [{
-              reference: "MedicationRequest/med-req-x"
+              reference: "med-req-x"
             }],
             statusReasonCodeableConcept: {
               text: "Not available"
@@ -809,7 +801,7 @@ describe("mergePrescriptionDetails", () => {
 
     const result = mergePrescriptionDetails(mockBundle)
 
-    expect(result.prescribedItems).toHaveLength(2)
+    expect(result.prescribedItems).toHaveLength(1)
     expect(result.prescribedItems[0]).toEqual({
       medicationName: "Drug X",
       quantity: "10",
@@ -976,7 +968,7 @@ describe("mergePrescriptionDetails", () => {
           resource: {
             resourceType: "MedicationDispense",
             // missing medicationCodeableConcept, quantity, dosageInstruction
-            status: "entered-in-error"
+            status: "in-progress"
             // no extension for non-dispensing reason
           }
         }


### PR DESCRIPTION
## Summary

stop duplication of prescribed items in the dispensed items array


- :robot: Operational or Infrastructure Change
