### PR TITLE
Fix: [AEA-0000] - handle subsequent user visit in rum

### DIFF
--- a/.github/scripts/fix_cdk_json.sh
+++ b/.github/scripts/fix_cdk_json.sh
@@ -3,6 +3,10 @@ set -e
 
 # script used to set context key values in cdk.json pre deployment from environment variables
 
+# set retry on aws commands
+AWS_MAX_ATTEMPTS=20
+export AWS_MAX_ATTEMPTS
+
 # helper function to set string values
 fix_string_key() {
     KEY_NAME=$1

--- a/.github/workflows/release_all_stacks.yml
+++ b/.github/workflows/release_all_stacks.yml
@@ -46,7 +46,7 @@ on:
       useCustomCognitoDomain:
         type: boolean
       LOG_LEVEL:
-          type: string
+        type: string
       APIGEE_CIS2_TOKEN_ENDPOINT:
         type: string
       APIGEE_MOCK_TOKEN_ENDPOINT:
@@ -156,7 +156,7 @@ jobs:
           role-to-assume: ${{ secrets.CLOUD_FORMATION_DEPLOY_ROLE }}
           role-session-name: prescription-clinical-tracker-ui-deployment
           output-credentials: true
-  
+
       - name: check redeploy stateful stack
         id: check_redeploy_stateful_stack
         run: |
@@ -277,6 +277,8 @@ jobs:
         shell: bash
       - name: Set Environment Variables for website deployment
         id: setup_env_website_deployment
+        env:
+          AWS_MAX_ATTEMPTS: 20
         run: |
           CF_LONDON_EXPORTS=$(aws cloudformation list-exports --region eu-west-2 --output json)
           CF_US_EXPORTS=$(aws cloudformation list-exports --region us-east-1 --output json)
@@ -569,7 +571,6 @@ jobs:
         with:
           RELEASE_TAG: ${{ inputs.VERSION_NUMBER }}
           DEV_CLOUD_FORMATION_EXECUTE_LAMBDA_ROLE: ${{ secrets.DEV_CLOUD_FORMATION_EXECUTE_LAMBDA_ROLE }}
-
 
   update_github_pages:
     runs-on: ubuntu-22.04

--- a/packages/cpt-ui/__tests__/awsRumHelper.test.tsx
+++ b/packages/cpt-ui/__tests__/awsRumHelper.test.tsx
@@ -3,6 +3,11 @@ import {render} from "@testing-library/react"
 import {AwsRumProvider} from "@/context/AwsRumProvider" // Adjust import path as needed
 import {AwsRum} from "aws-rum-web"
 import {APP_CONFIG, RUM_CONFIG} from "@/constants/environment"
+import {readItemGroupFromLocalStorage} from "@/helpers/useLocalStorageState"
+
+jest.mock("@/helpers/useLocalStorageState", () => ({
+  readItemGroupFromLocalStorage: jest.fn()
+}))
 
 // Mock aws-rum-web and RUM_CONFIG
 jest.mock("aws-rum-web", () => {
@@ -39,7 +44,74 @@ describe("AwsRumHelper", () => {
     jest.clearAllMocks()
   })
 
-  it("should initialize AwsRum with correct config", () => {
+  it("should initialize AwsRum with correct config when cookie consent not set", () => {
+    (readItemGroupFromLocalStorage as jest.Mock)
+      .mockReturnValueOnce({})
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, no-undef
+    const rum = new (require("@/helpers/awsRum").CptAwsRum)()
+
+    // Check that AwsRum constructor was called with correct parameters
+    expect(AwsRum).toHaveBeenCalledWith(
+      RUM_CONFIG.APPLICATION_ID,
+      RUM_CONFIG.VERSION,
+      RUM_CONFIG.REGION,
+      {
+        sessionSampleRate: RUM_CONFIG.SESSION_SAMPLE_RATE,
+        guestRoleArn: RUM_CONFIG.GUEST_ROLE_ARN,
+        identityPoolId: RUM_CONFIG.IDENTITY_POOL_ID,
+        endpoint: RUM_CONFIG.ENDPOINT,
+        telemetries: RUM_CONFIG.TELEMETRIES,
+        allowCookies: false,
+        enableXRay: RUM_CONFIG.ENABLE_XRAY,
+        releaseId: RUM_CONFIG.RELEASE_ID,
+        sessionEventLimit: 0,
+        sessionAttributes: {
+          cptAppVersion: APP_CONFIG.VERSION_NUMBER,
+          cptAppCommit: APP_CONFIG.COMMIT_ID
+        },
+        cookieAttributes: {secure: true, sameSite: "strict"}
+      }
+    )
+    expect(rum.getAwsRum()).not.toBeNull()
+  })
+
+  it("should initialize AwsRum with correct config when cookie consent set to accepted", () => {
+    (readItemGroupFromLocalStorage as jest.Mock)
+      .mockReturnValueOnce({"epsCookieConsent": "accepted"})
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, no-undef
+    const rum = new (require("@/helpers/awsRum").CptAwsRum)()
+
+    // Check that AwsRum constructor was called with correct parameters
+    expect(AwsRum).toHaveBeenCalledWith(
+      RUM_CONFIG.APPLICATION_ID,
+      RUM_CONFIG.VERSION,
+      RUM_CONFIG.REGION,
+      {
+        sessionSampleRate: RUM_CONFIG.SESSION_SAMPLE_RATE,
+        guestRoleArn: RUM_CONFIG.GUEST_ROLE_ARN,
+        identityPoolId: RUM_CONFIG.IDENTITY_POOL_ID,
+        endpoint: RUM_CONFIG.ENDPOINT,
+        telemetries: RUM_CONFIG.TELEMETRIES,
+        allowCookies: true,
+        enableXRay: RUM_CONFIG.ENABLE_XRAY,
+        releaseId: RUM_CONFIG.RELEASE_ID,
+        sessionEventLimit: 0,
+        sessionAttributes: {
+          cptAppVersion: APP_CONFIG.VERSION_NUMBER,
+          cptAppCommit: APP_CONFIG.COMMIT_ID
+        },
+        cookieAttributes: {secure: true, sameSite: "strict"}
+      }
+    )
+    expect(rum.getAwsRum()).not.toBeNull()
+  })
+
+  it("should initialize AwsRum with correct config when cookie consent set to rejected", () => {
+    (readItemGroupFromLocalStorage as jest.Mock)
+      .mockReturnValueOnce({"epsCookieConsent": "rejected"})
+
     // eslint-disable-next-line @typescript-eslint/no-require-imports, no-undef
     const rum = new (require("@/helpers/awsRum").CptAwsRum)()
 

--- a/packages/cpt-ui/package.json
+++ b/packages/cpt-ui/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "compile": "tsc --build",
     "dev": "vite --host",
-    "build": "tsc --build && vite build --debug",
+    "build": "tsc --build && vite build",
     "lint": "eslint  --max-warnings 0 --fix --config ../../eslint.config.mjs .",
     "start": "vite preview",
     "test": "NODE_NO_WARNINGS=1 jest --no-cache --coverage",

--- a/packages/cpt-ui/src/components/EPSCookieBanner.tsx
+++ b/packages/cpt-ui/src/components/EPSCookieBanner.tsx
@@ -21,7 +21,8 @@ export default function EPSCookieBanner() {
   const [showConfirmationBanner, setShowConfirmationBanner] = useState(false)
 
   // this is shared between this component and cookiePolicyPage so use useLocalStorageState
-  const [cookiesSet, setCookiesSet] = useLocalStorageState<boolean>("setCookiesSet", "setCookiesSet", false)
+  const [cookiePreferencesSaved, setCookiePreferencesSaved] =
+    useLocalStorageState<boolean>("cookiePreferencesSaved", "cookiePreferencesSaved", false)
   const [epsCookieConsent, setEpsCookieConsent] = useLocalStorageState<"accepted" | "rejected" | null>(
     "epsCookieConsent", "epsCookieConsent", null)
   const [epsConfirmationBannerShown, setEpsConfirmationBannerShown] = useLocalStorageState<boolean>(
@@ -30,7 +31,7 @@ export default function EPSCookieBanner() {
   const checkCookieConsent = () => {
 
     if (epsCookieConsent === "accepted" || epsCookieConsent === "rejected") {
-      setCookiesSet(true)
+      setCookiePreferencesSaved(true)
 
       if (!epsConfirmationBannerShown) {
         setShowConfirmationBanner(true)
@@ -39,7 +40,7 @@ export default function EPSCookieBanner() {
     } else if (typeof window !== "undefined" && window.NHSCookieConsent?.getConsented()) {
       const hasAnalytics = window.NHSCookieConsent.getStatistics()
       const initialChoice = hasAnalytics ? "accepted" : "rejected"
-      setCookiesSet(true)
+      setCookiePreferencesSaved(true)
       setEpsCookieConsent(initialChoice)
 
       setShowConfirmationBanner(true)
@@ -60,7 +61,7 @@ export default function EPSCookieBanner() {
   }, [location.pathname])
 
   const handleCookieChoice = (choice: "accepted" | "rejected") => {
-    setCookiesSet(true)
+    setCookiePreferencesSaved(true)
     setEpsCookieConsent(choice)
     if (choice === "accepted") {
       cptAwsRum.enable()
@@ -78,7 +79,7 @@ export default function EPSCookieBanner() {
 
   return (
     <Fragment>
-      {!cookiesSet && (
+      {!cookiePreferencesSaved && (
         <div
           className="nhsuk-cookie-banner"
           data-testid="cookieBanner"

--- a/packages/cpt-ui/src/helpers/awsRum.tsx
+++ b/packages/cpt-ui/src/helpers/awsRum.tsx
@@ -1,11 +1,14 @@
 import {APP_CONFIG, RUM_CONFIG} from "@/constants/environment"
 import {AwsRum, AwsRumConfig, Telemetry} from "aws-rum-web"
+import {readItemGroupFromLocalStorage} from "./useLocalStorageState"
 
 export class CptAwsRum {
   awsRum: AwsRum | null
 
   constructor() {
-    this.awsRum = this.initRum(false) // initialize with cookies disabled
+    const {epsCookieConsent: consent} = readItemGroupFromLocalStorage("epsCookieConsent") || {}
+    const allowCookies = consent ? consent === "accepted" : false
+    this.awsRum = this.initRum(allowCookies) // initialize with cookies disabled
   }
 
   public getAwsRum() {
@@ -33,6 +36,7 @@ export class CptAwsRum {
 
   private initRum(allowCookies: boolean) {
     let awsRum: AwsRum | null = null
+    // see if we have already accepted cookies
     try {
       let telemetries: Array<Telemetry> = RUM_CONFIG.TELEMETRIES
       if (telemetries.includes("http")) {

--- a/packages/cpt-ui/src/pages/CookiePolicyPage.tsx
+++ b/packages/cpt-ui/src/pages/CookiePolicyPage.tsx
@@ -23,7 +23,8 @@ const CookiePolicyPage = () => {
 
   // these are shared between this page and the cookie banner component so use useLocalStorageState
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [cookiesSet, setCookiesSet] = useLocalStorageState<boolean>("setCookiesSet", "setCookiesSet", false)
+  const [cookiePreferencesSaved, setCookiePreferencesSaved] =
+    useLocalStorageState<boolean>("cookiePreferencesSaved", "cookiePreferencesSaved", false)
   const [epsCookieConsent, setEpsCookieConsent] = useLocalStorageState<"accepted" | "rejected" | null>(
     "epsCookieConsent", "epsCookieConsent", null)
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -44,23 +45,23 @@ const CookiePolicyPage = () => {
       const initialChoice = hasAnalytics ? "accepted" : "rejected"
       setLocalCookieChoice(initialChoice)
       setEpsCookieConsent(initialChoice)
-      setCookiesSet(true)
+      setCookiePreferencesSaved(true)
     } else {
-      setCookiesSet(false)
+      setCookiePreferencesSaved(false)
     }
 
     setHasInitialized(true)
   }, [hasInitialized])
 
   const saveCookieChoice = (choice: "accepted" | "rejected") => {
+    setCookiePreferencesSaved(true)
+    setEpsCookieConsent(choice)
+    setEpsConfirmationBannerShown(true)
     if (choice === "accepted") {
       cptAwsRum.enable()
     } else {
       cptAwsRum.disable()
     }
-    setCookiesSet(true)
-    setEpsCookieConsent(choice)
-    setEpsConfirmationBannerShown(true)
     if (typeof window !== "undefined" && window.NHSCookieConsent) {
       window.NHSCookieConsent.setStatistics(choice === "accepted")
       window.NHSCookieConsent.setConsented(true)


### PR DESCRIPTION
## Summary

- Routine Change

### Details

- set allowCookies when initialising rum client based on already selected user preferences if available
- set AWS_MAX_ATTEMPTS in fix_cdk_json script and when deploying website
- remove debug output when building website
- rename variable to record if cookie preferences saved to cookiePreferencesSaved 