### PR TITLE
Fix: [AEA-6434] - Support both status history extension urls

### DIFF
--- a/packages/prescriptionDetailsLambda/src/utils/types.ts
+++ b/packages/prescriptionDetailsLambda/src/utils/types.ts
@@ -84,9 +84,11 @@ export const extensionUrlMappings = {
     "https://fhir.nhs.uk/StructureDefinition/Extension-EPS-TaskBusinessStatus"
   ],
   PRESCRIPTION_STATUS_HISTORY: [
-    "https://fhir.nhs.uk/StructureDefinition/Extension-DM-PrescriptionStatusHistory"
+    "https://fhir.nhs.uk/StructureDefinition/Extension-DM-PrescriptionStatusHistory",
+    "https://fhir.nhs.uk/StructureDefinition/Extension-EPS-PrescriptionStatusHistory" //old
   ],
   DM_PRESCRIPTION_STATUS_UPDATE_HISTORY: [
-    "https://fhir.nhs.uk/StructureDefinition/Extension-DM-PrescriptionStatusHistory"
+    "https://fhir.nhs.uk/StructureDefinition/Extension-DM-PrescriptionStatusHistory",
+    "https://fhir.nhs.uk/StructureDefinition/Extension-EPS-PrescriptionStatusHistory" //old
   ]
 } satisfies Record<string, Array<string>>

--- a/packages/prescriptionDetailsLambda/src/utils/types.ts
+++ b/packages/prescriptionDetailsLambda/src/utils/types.ts
@@ -88,7 +88,6 @@ export const extensionUrlMappings = {
     "https://fhir.nhs.uk/StructureDefinition/Extension-EPS-PrescriptionStatusHistory" //old
   ],
   DM_PRESCRIPTION_STATUS_UPDATE_HISTORY: [
-    "https://fhir.nhs.uk/StructureDefinition/Extension-DM-PrescriptionStatusHistory",
-    "https://fhir.nhs.uk/StructureDefinition/Extension-EPS-PrescriptionStatusHistory" //old
+    "https://fhir.nhs.uk/StructureDefinition/Extension-DM-PrescriptionStatusHistory"
   ]
 } satisfies Record<string, Array<string>>

--- a/packages/prescriptionDetailsLambda/tests/test_fhirMapper.test.ts
+++ b/packages/prescriptionDetailsLambda/tests/test_fhirMapper.test.ts
@@ -227,6 +227,28 @@ describe("extractPrescribedItems", () => {
     expect(result[0].pharmacyStatus).toBe("Dispatched")
   })
 
+  // old extension
+  it("should extract pharmacyStatus from EPS prescription status update extension", () => {
+    const medicationRequests: Array<MedicationRequest> = [
+      {
+        resourceType: "MedicationRequest",
+        status: "active",
+        intent: "order",
+        subject: {},
+        extension: [
+          {
+            url: "https://fhir.nhs.uk/StructureDefinition/Extension-EPS-PrescriptionStatusHistory",
+            extension: [
+              {url: "status", valueCoding: {code: "Dispatched"}}
+            ]
+          }
+        ]
+      }
+    ]
+    const result = extractItems(medicationRequests, [])
+    expect(result[0].pharmacyStatus).toBe("Dispatched")
+  })
+
   it("should return undefined pharmacyStatus if DM extension is missing", () => {
     const medicationRequests: Array<MedicationRequest> = [
       {

--- a/packages/prescriptionDetailsLambda/tests/test_fhirMapper.test.ts
+++ b/packages/prescriptionDetailsLambda/tests/test_fhirMapper.test.ts
@@ -227,28 +227,6 @@ describe("extractPrescribedItems", () => {
     expect(result[0].pharmacyStatus).toBe("Dispatched")
   })
 
-  // old extension
-  it("should extract pharmacyStatus from EPS prescription status update extension", () => {
-    const medicationRequests: Array<MedicationRequest> = [
-      {
-        resourceType: "MedicationRequest",
-        status: "active",
-        intent: "order",
-        subject: {},
-        extension: [
-          {
-            url: "https://fhir.nhs.uk/StructureDefinition/Extension-EPS-PrescriptionStatusHistory",
-            extension: [
-              {url: "status", valueCoding: {code: "Dispatched"}}
-            ]
-          }
-        ]
-      }
-    ]
-    const result = extractItems(medicationRequests, [])
-    expect(result[0].pharmacyStatus).toBe("Dispatched")
-  })
-
   it("should return undefined pharmacyStatus if DM extension is missing", () => {
     const medicationRequests: Array<MedicationRequest> = [
       {

--- a/packages/prescriptionListLambda/src/utils/responseMapper.ts
+++ b/packages/prescriptionListLambda/src/utils/responseMapper.ts
@@ -98,7 +98,11 @@ export const mapResponseToPrescriptionSummary = (
 
     // Extract status code - fixed to match the structure
     const statusExtension = resource.extension?.find(ext =>
-      ext.url === "https://fhir.nhs.uk/StructureDefinition/Extension-DM-PrescriptionStatusHistory"
+      // ext.url === "https://fhir.nhs.uk/StructureDefinition/Extension-DM-PrescriptionStatusHistory"
+      [
+        "https://fhir.nhs.uk/StructureDefinition/Extension-DM-PrescriptionStatusHistory",
+        "https://fhir.nhs.uk/StructureDefinition/Extension-EPS-PrescriptionStatusHistory" // old
+      ].includes(ext.url)
     )
     const statusCode = statusExtension?.extension?.find(ext =>
       ext.url === "status"

--- a/packages/prescriptionListLambda/tests/test_responseMapper.test.ts
+++ b/packages/prescriptionListLambda/tests/test_responseMapper.test.ts
@@ -271,7 +271,7 @@ describe("Response Mapper Tests", () => {
               authoredOn: "20250204000000",
               extension: [
                 {
-                  url: "https://fhir.nhs.uk/StructureDefinition/Extension-DM-PrescriptionStatusHistory",
+                  url: "https://fhir.nhs.uk/StructureDefinition/Extension-EPS-PrescriptionStatusHistory", //old
                   extension: [{
                     url: "status",
                     valueCoding : {


### PR DESCRIPTION
## Summary
- Routine Change
- :warning: Potential issues that might be caused by this change

### Details
Updates backend to support both status history extension urls