### PR TITLE
Update: [AEA-6504] - Adds support for new pending cancellation extension format

### DIFF
--- a/packages/common/commonTypes/src/prescriptionList.ts
+++ b/packages/common/commonTypes/src/prescriptionList.ts
@@ -38,8 +38,6 @@ export interface PrescriptionSummary {
   prescriptionTreatmentType: TreatmentType
   issueNumber?: number
   maxRepeats?: number
-  // prescriptionPendingCancellation: boolean
-  // itemsPendingCancellation: boolean
   pendingCancellation: boolean
   nhsNumber?: string
 }

--- a/packages/common/commonTypes/src/prescriptionList.ts
+++ b/packages/common/commonTypes/src/prescriptionList.ts
@@ -38,8 +38,9 @@ export interface PrescriptionSummary {
   prescriptionTreatmentType: TreatmentType
   issueNumber?: number
   maxRepeats?: number
-  prescriptionPendingCancellation: boolean
-  itemsPendingCancellation: boolean
+  // prescriptionPendingCancellation: boolean
+  // itemsPendingCancellation: boolean
+  pendingCancellation: boolean
   nhsNumber?: string
 }
 

--- a/packages/cpt-ui/__tests__/EpsPrescriptionList.test.tsx
+++ b/packages/cpt-ui/__tests__/EpsPrescriptionList.test.tsx
@@ -209,8 +209,7 @@ const mockSearchResponse: SearchResponse = {
       prescriptionTreatmentType: TreatmentType.REPEAT,
       issueNumber: 1,
       maxRepeats: 5,
-      prescriptionPendingCancellation: false,
-      itemsPendingCancellation: false
+      pendingCancellation: false
     },
     {
       prescriptionId: "209E3D-A83008-327F9F",
@@ -220,8 +219,7 @@ const mockSearchResponse: SearchResponse = {
       prescriptionTreatmentType: TreatmentType.ACUTE,
       issueNumber: 2,
       maxRepeats: 3,
-      prescriptionPendingCancellation: false,
-      itemsPendingCancellation: false
+      pendingCancellation: false
     },
     {
       prescriptionId: "RX003",
@@ -231,8 +229,7 @@ const mockSearchResponse: SearchResponse = {
       prescriptionTreatmentType: TreatmentType.ERD,
       issueNumber: 3,
       maxRepeats: 4,
-      prescriptionPendingCancellation: false,
-      itemsPendingCancellation: true
+      pendingCancellation: false
     }
   ],
   pastPrescriptions: [
@@ -244,8 +241,7 @@ const mockSearchResponse: SearchResponse = {
       prescriptionTreatmentType: TreatmentType.REPEAT,
       issueNumber: 1,
       maxRepeats: 2,
-      prescriptionPendingCancellation: false,
-      itemsPendingCancellation: false
+      pendingCancellation: false
     },
     {
       prescriptionId: "RX005",
@@ -255,8 +251,7 @@ const mockSearchResponse: SearchResponse = {
       prescriptionTreatmentType: TreatmentType.ACUTE,
       issueNumber: 1,
       maxRepeats: 1,
-      prescriptionPendingCancellation: false,
-      itemsPendingCancellation: false
+      pendingCancellation: false
     }
   ],
   futurePrescriptions: [
@@ -268,8 +263,7 @@ const mockSearchResponse: SearchResponse = {
       prescriptionTreatmentType: TreatmentType.REPEAT,
       issueNumber: 1,
       maxRepeats: 10,
-      prescriptionPendingCancellation: false,
-      itemsPendingCancellation: false
+      pendingCancellation: false
     }
   ]
 }

--- a/packages/cpt-ui/__tests__/PrescriptionListPage.test.tsx
+++ b/packages/cpt-ui/__tests__/PrescriptionListPage.test.tsx
@@ -126,8 +126,7 @@ const mockPrescription: PrescriptionSummary = {
   statusCode: "0001",
   issueDate: "2024-01-15T10:30:00Z",
   prescriptionTreatmentType: TreatmentType.ACUTE,
-  prescriptionPendingCancellation: false,
-  itemsPendingCancellation: false
+  pendingCancellation: false
 }
 
 const mockSearchResponse: SearchResponse = {

--- a/packages/cpt-ui/__tests__/PrescriptionListTab.test.tsx
+++ b/packages/cpt-ui/__tests__/PrescriptionListTab.test.tsx
@@ -45,8 +45,7 @@ describe("PrescriptionsListTabs", () => {
       prescriptionTreatmentType: TreatmentType.REPEAT,
       issueNumber: 1,
       maxRepeats: 5,
-      prescriptionPendingCancellation: false,
-      itemsPendingCancellation: false
+      pendingCancellation: false
     },
     {
       prescriptionId: "209E3D-A83008-327F9F",
@@ -56,8 +55,7 @@ describe("PrescriptionsListTabs", () => {
       prescriptionTreatmentType: TreatmentType.REPEAT,
       issueNumber: 1,
       maxRepeats: 5,
-      prescriptionPendingCancellation: false,
-      itemsPendingCancellation: false
+      pendingCancellation: false
     }
   ]
 
@@ -70,8 +68,7 @@ describe("PrescriptionsListTabs", () => {
       prescriptionTreatmentType: TreatmentType.ACUTE,
       issueNumber: 1,
       maxRepeats: 5,
-      prescriptionPendingCancellation: false,
-      itemsPendingCancellation: false
+      pendingCancellation: false
     }
   ]
 
@@ -84,8 +81,7 @@ describe("PrescriptionsListTabs", () => {
       prescriptionTreatmentType: TreatmentType.REPEAT,
       issueNumber: 1,
       maxRepeats: 5,
-      prescriptionPendingCancellation: false,
-      itemsPendingCancellation: false
+      pendingCancellation: false
     },
     {
       prescriptionId: "RX005",
@@ -95,8 +91,7 @@ describe("PrescriptionsListTabs", () => {
       prescriptionTreatmentType: TreatmentType.REPEAT,
       issueNumber: 1,
       maxRepeats: 5,
-      prescriptionPendingCancellation: false,
-      itemsPendingCancellation: false
+      pendingCancellation: false
     },
     {
       prescriptionId: "RX006",
@@ -106,8 +101,7 @@ describe("PrescriptionsListTabs", () => {
       prescriptionTreatmentType: TreatmentType.REPEAT,
       issueNumber: 1,
       maxRepeats: 5,
-      prescriptionPendingCancellation: false,
-      itemsPendingCancellation: false
+      pendingCancellation: false
     }
   ]
 
@@ -195,8 +189,7 @@ describe("PrescriptionsListTabs", () => {
       prescriptionTreatmentType: TreatmentType.REPEAT,
       issueNumber: 1,
       maxRepeats: 2,
-      prescriptionPendingCancellation: false,
-      itemsPendingCancellation: false
+      pendingCancellation: false
     }
 
     const testPage = (

--- a/packages/cpt-ui/__tests__/PrescriptionListTable.test.tsx
+++ b/packages/cpt-ui/__tests__/PrescriptionListTable.test.tsx
@@ -101,8 +101,7 @@ describe("PrescriptionsListTable", () => {
       prescriptionTreatmentType: TreatmentType.ACUTE,
       issueNumber: 1,
       maxRepeats: 5,
-      prescriptionPendingCancellation: false,
-      itemsPendingCancellation: false
+      pendingCancellation: false
     },
     {
       prescriptionId: "209E3D-A83008-327F9F",
@@ -112,8 +111,7 @@ describe("PrescriptionsListTable", () => {
       prescriptionTreatmentType: TreatmentType.REPEAT,
       issueNumber: 2,
       maxRepeats: 5,
-      prescriptionPendingCancellation: true,
-      itemsPendingCancellation: false
+      pendingCancellation: true
     },
     {
       prescriptionId: "209E3D-A83008-327FXZ",
@@ -123,8 +121,7 @@ describe("PrescriptionsListTable", () => {
       prescriptionTreatmentType: TreatmentType.REPEAT,
       issueNumber: 3,
       maxRepeats: 10,
-      prescriptionPendingCancellation: false,
-      itemsPendingCancellation: true
+      pendingCancellation: true
     }
   ]
 
@@ -350,8 +347,7 @@ describe("PrescriptionsListTable", () => {
         prescriptionTreatmentType: TreatmentType.REPEAT,
         issueNumber: 3,
         maxRepeats: 6,
-        prescriptionPendingCancellation: false,
-        itemsPendingCancellation: false
+        pendingCancellation: false
       },
       {
         prescriptionId: "7F1A4B-A83008-91DC2E",
@@ -361,8 +357,7 @@ describe("PrescriptionsListTable", () => {
         prescriptionTreatmentType: TreatmentType.REPEAT,
         issueNumber: 2,
         maxRepeats: 5,
-        prescriptionPendingCancellation: false,
-        itemsPendingCancellation: false
+        pendingCancellation: false
       },
       {
         prescriptionId: "4D6F2C-A83008-A3E7D1",
@@ -372,8 +367,7 @@ describe("PrescriptionsListTable", () => {
         prescriptionTreatmentType: TreatmentType.REPEAT,
         issueNumber: 1,
         maxRepeats: 4,
-        prescriptionPendingCancellation: false,
-        itemsPendingCancellation: false
+        pendingCancellation: false
       }
     ]
 
@@ -448,8 +442,7 @@ describe("PrescriptionsListTable", () => {
       prescriptionTreatmentType: TreatmentType.ACUTE,
       issueNumber: 1,
       maxRepeats: 1,
-      prescriptionPendingCancellation: false,
-      itemsPendingCancellation: false
+      pendingCancellation: false
     }
 
     renderWithRouter(

--- a/packages/cpt-ui/src/components/prescriptionList/PrescriptionsListTable.tsx
+++ b/packages/cpt-ui/src/components/prescriptionList/PrescriptionsListTable.tsx
@@ -154,10 +154,8 @@ const PrescriptionsListTable = ({
 
     sorted.sort((a, b) => {
       if (sortConfig.key === "cancellationWarning") {
-        const aHasWarning =
-          a.prescriptionPendingCancellation || a.itemsPendingCancellation
-        const bHasWarning =
-          b.prescriptionPendingCancellation || b.itemsPendingCancellation
+        const aHasWarning = a.pendingCancellation
+        const bHasWarning = b.pendingCancellation
 
         if (aHasWarning === bHasWarning) {
           const aDateTimestamp = getValidDateTimestamp(a.issueDate)
@@ -316,9 +314,7 @@ const PrescriptionsListTable = ({
     }
 
     if (key === "cancellationWarning") {
-      const showWarning =
-        row.prescriptionPendingCancellation ||
-        row.itemsPendingCancellation
+      const showWarning = row.pendingCancellation
       return (
         <Table.Cell
           key={key}

--- a/packages/prescriptionDetailsLambda/src/utils/fhirMappers.ts
+++ b/packages/prescriptionDetailsLambda/src/utils/fhirMappers.ts
@@ -97,7 +97,7 @@ export const extractItems = (
 
     // determine if initiallyPrescribed should be included (only if different from dispensed)
 
-    // get prescription level pending cancellation status
+    // get line item level pending cancellation status
     let itemPendingCancellation: boolean
     const pendingCancellationExt = findExtensionByKey(request.extension, "PENDING_CANCELLATION")
     if (pendingCancellationExt?.extension){

--- a/packages/prescriptionDetailsLambda/src/utils/fhirMappers.ts
+++ b/packages/prescriptionDetailsLambda/src/utils/fhirMappers.ts
@@ -1,6 +1,6 @@
 import {MedicationDispense, MedicationRequest} from "fhir/r4"
 import {ItemDetails} from "@cpt-ui-common/common-types"
-import {findExtensionByKey, getBooleanFromNestedExtension, getCodeFromNestedExtension} from "./extensionUtils"
+import {findExtensionByKey, getCodeFromNestedExtension} from "./extensionUtils"
 import {Logger} from "@aws-lambda-powertools/logger"
 
 /**
@@ -96,8 +96,19 @@ export const extractItems = (
     const notDispensedReason = correspondingDispense?.statusReasonCodeableConcept?.coding?.[0]?.code
 
     // determine if initiallyPrescribed should be included (only if different from dispensed)
+
+    // get prescription level pending cancellation status
+    let itemPendingCancellation: boolean
     const pendingCancellationExt = findExtensionByKey(request.extension, "PENDING_CANCELLATION")
-    const itemPendingCancellation = getBooleanFromNestedExtension(pendingCancellationExt, "lineItemPendingCancellation")
+    if (pendingCancellationExt?.extension){
+    // handle old sub extension
+      itemPendingCancellation = pendingCancellationExt.extension.find(
+        ext => ext.url === "lineItemPendingCancellation")?.valueBoolean || false
+    } else {
+    // handle new single value extension
+      itemPendingCancellation = pendingCancellationExt?.valueBoolean || false
+    }
+
     const cancellationReason = request.statusReason?.text ?? request.statusReason?.coding?.[0]?.code
 
     const businessStatusExt = findExtensionByKey(request.extension, "DISPENSING_INFORMATION")

--- a/packages/prescriptionDetailsLambda/src/utils/responseMapper.ts
+++ b/packages/prescriptionDetailsLambda/src/utils/responseMapper.ts
@@ -12,7 +12,6 @@ import {mapPrescriptionOrigin, mapMessageHistoryTitleToMessageCode, extractItems
 import {
   findExtensionByKey,
   findExtensionsByKey,
-  getBooleanFromNestedExtension,
   getIntegerFromNestedExtension,
   PrescriptionOdsCodes
 } from "./extensionUtils"
@@ -206,11 +205,17 @@ export const mergePrescriptionDetails = (
   )[0]
   const daysSupply = lineItemsAction.timingTiming?.repeat!.period!.toString() ?? "Not applicable"
 
-  // get pending cancellation status
-  const prescriptionPendingCancellation = getBooleanFromNestedExtension(
-    findExtensionByKey(requestGroup.extension, "PENDING_CANCELLATION"),
-    "prescriptionPendingCancellation"
-  )
+  // get prescription level pending cancellation status
+  let prescriptionPendingCancellation: boolean
+  const pendingCancellationExt = findExtensionByKey(requestGroup.extension, "PENDING_CANCELLATION")
+  if (pendingCancellationExt?.extension){
+    // handle old sub extension
+    prescriptionPendingCancellation = pendingCancellationExt.extension.find(
+      ext => ext.url === "prescriptionPendingCancellation")?.valueBoolean || false
+  } else {
+    // handle new single value extension
+    prescriptionPendingCancellation = pendingCancellationExt?.valueBoolean || false
+  }
 
   // extract and format all the data
   const patientDetails: PatientSummary = {

--- a/packages/prescriptionDetailsLambda/tests/test_fhirMapper.test.ts
+++ b/packages/prescriptionDetailsLambda/tests/test_fhirMapper.test.ts
@@ -111,7 +111,8 @@ describe("extractPrescribedItems", () => {
     })
   })
 
-  it("should extract pending cancellation status from extensions", () => {
+  // old pending cancellation
+  it("should extract pending cancellation status from old format extensions", () => {
     const medicationRequests: Array<MedicationRequest> = [
       {
         resourceType: "MedicationRequest",
@@ -124,6 +125,27 @@ describe("extractPrescribedItems", () => {
             extension: [
               {url: "lineItemPendingCancellation", valueBoolean: true}
             ]
+          }
+        ]
+      }
+    ]
+
+    const result = extractItems(medicationRequests, [])
+    expect(result[0].itemPendingCancellation).toBe(true)
+  })
+
+  // new pending cancellation
+  it("should extract pending cancellation status from extensions", () => {
+    const medicationRequests: Array<MedicationRequest> = [
+      {
+        resourceType: "MedicationRequest",
+        status: "active",
+        intent: "order",
+        subject: {},
+        extension: [
+          {
+            url: "https://fhir.nhs.uk/StructureDefinition/Extension-PendingCancellation",
+            valueBoolean: true
           }
         ]
       }

--- a/packages/prescriptionDetailsLambda/tests/test_responseMapper.test.ts
+++ b/packages/prescriptionDetailsLambda/tests/test_responseMapper.test.ts
@@ -696,4 +696,39 @@ describe("mergePrescriptionDetails", () => {
       notDispensedReason: undefined
     }])
   })
+
+  // old pending cancellation
+  it("should handle the old format of the pending cancellation extension", () => {
+    medicationRequest.extension![1].extension![0].valueBoolean = true
+    const result = mergePrescriptionDetails(prescriptionBundle, {}, odsCodes)
+
+    expect(result.items).toEqual([{
+      medicationName: "Drug A",
+      quantity: "20",
+      dosageInstructions: "Take two daily",
+      epsStatusCode: "0007",
+      pharmacyStatus: undefined,
+      itemPendingCancellation: true,
+      cancellationReason: undefined,
+      notDispensedReason: undefined
+    }])
+  })
+
+  // new pending cancellation
+  it("should handle the pending cancellation extension", () => {
+    delete medicationRequest.extension![1].extension
+    medicationRequest.extension![1].valueBoolean = true
+    const result = mergePrescriptionDetails(prescriptionBundle, {}, odsCodes)
+
+    expect(result.items).toEqual([{
+      medicationName: "Drug A",
+      quantity: "20",
+      dosageInstructions: "Take two daily",
+      epsStatusCode: "0007",
+      pharmacyStatus: undefined,
+      itemPendingCancellation: true,
+      cancellationReason: undefined,
+      notDispensedReason: undefined
+    }])
+  })
 })

--- a/packages/prescriptionListLambda/src/utils/responseMapper.ts
+++ b/packages/prescriptionListLambda/src/utils/responseMapper.ts
@@ -124,18 +124,24 @@ export const mapResponseToPrescriptionSummary = (
       ext.url === "numberOfRepeatsIssued"
     )?.valueInteger
 
-    // Extract pending cancellation - fixed to match the structure
+    // Extract pending cancellation
+    let pendingCancellation = false
     const pendingCancellationExt = resource.extension?.find(ext =>
       ext.url === "https://fhir.nhs.uk/StructureDefinition/Extension-PendingCancellation"
     )
 
-    const prescriptionPendingCancellation = pendingCancellationExt?.extension?.find(ext =>
-      ext.url === "prescriptionPendingCancellation"
-    )?.valueBoolean || false
-
-    const itemsPendingCancellation = pendingCancellationExt?.extension?.find(ext =>
-      ext.url === "lineItemPendingCancellation"
-    )?.valueBoolean || false
+    if(pendingCancellationExt?.extension){
+      // handle old split extension
+      for(const extension of pendingCancellationExt.extension){
+        // if either is true set overarching pendingCancellation as true
+        if (extension.valueBoolean){
+          pendingCancellation = true
+        }
+      }
+    } else {
+      // handle new combined extension
+      pendingCancellation = pendingCancellationExt?.valueBoolean || false
+    }
 
     prescriptions.push({
       prescriptionId: resource.identifier?.[0]?.value as string,
@@ -143,8 +149,7 @@ export const mapResponseToPrescriptionSummary = (
       statusCode,
       issueDate: resource.authoredOn as string,
       prescriptionTreatmentType: treatmentType,
-      prescriptionPendingCancellation,
-      itemsPendingCancellation,
+      pendingCancellation,
       maxRepeats,
       issueNumber,
       nhsNumber,

--- a/packages/prescriptionListLambda/tests/test_handler.test.ts
+++ b/packages/prescriptionListLambda/tests/test_handler.test.ts
@@ -99,10 +99,9 @@ describe("handler tests with cis2 auth", () => {
     expect(responseBody).toEqual({
       currentPrescriptions: [{
         issueDate: "2023-01-01",
-        itemsPendingCancellation: false,
         nhsNumber: "9999999999",
         prescriptionId: "01ABC123",
-        prescriptionPendingCancellation: false,
+        pendingCancellation: false,
         prescriptionTreatmentType: "0001",
         statusCode: "0001",
         isDeleted: false
@@ -150,10 +149,9 @@ describe("handler tests with cis2 auth", () => {
       currentPrescriptions: [{
         isDeleted: false,
         issueDate: "2023-01-01",
-        itemsPendingCancellation: false,
         nhsNumber: "9999999999",
         prescriptionId: "01ABC123",
-        prescriptionPendingCancellation: false,
+        pendingCancellation: false,
         prescriptionTreatmentType: "0001",
         statusCode: "0001"
       }],

--- a/packages/prescriptionListLambda/tests/test_prescriptionsLookupService.test.ts
+++ b/packages/prescriptionListLambda/tests/test_prescriptionsLookupService.test.ts
@@ -53,8 +53,7 @@ describe("Prescriptions Lookup Service Tests", () => {
         statusCode: "0001",
         issueDate: "2023-01-01",
         prescriptionTreatmentType: TreatmentType.ACUTE,
-        prescriptionPendingCancellation: false,
-        itemsPendingCancellation: false,
+        pendingCancellation: false,
         nhsNumber: "9999999999"
       })
     })
@@ -132,8 +131,7 @@ describe("Prescriptions Lookup Service Tests", () => {
         statusCode: "0001",
         issueDate: "2023-01-01",
         prescriptionTreatmentType: TreatmentType.ACUTE,
-        prescriptionPendingCancellation: false,
-        itemsPendingCancellation: false,
+        pendingCancellation: false,
         nhsNumber: "9999999999"
       })
     })

--- a/packages/prescriptionListLambda/tests/test_responseMapper.test.ts
+++ b/packages/prescriptionListLambda/tests/test_responseMapper.test.ts
@@ -53,8 +53,7 @@ describe("Response Mapper Tests", () => {
         statusCode: "0001",
         issueDate: "20250204000000",
         prescriptionTreatmentType: TreatmentType.ACUTE,
-        prescriptionPendingCancellation: false,
-        itemsPendingCancellation: false,
+        pendingCancellation: false,
         nhsNumber: "9999999111",
         given: ["Fall"],
         family: "Back"
@@ -75,8 +74,7 @@ describe("Response Mapper Tests", () => {
           statusCode: "0001",
           issueDate: "20250204000000",
           prescriptionTreatmentType: TreatmentType.ACUTE,
-          prescriptionPendingCancellation: false,
-          itemsPendingCancellation: false,
+          pendingCancellation: false,
           nhsNumber: "9999999111",
           given: ["Fall"],
           family: "Back"
@@ -140,8 +138,7 @@ describe("Response Mapper Tests", () => {
           statusCode: "0001",
           issueDate: "20250204000000",
           prescriptionTreatmentType: TreatmentType.ACUTE,
-          prescriptionPendingCancellation: false,
-          itemsPendingCancellation: false,
+          pendingCancellation: false,
           nhsNumber: "9999999111",
           given: ["Fall"],
           family: "Back"
@@ -152,8 +149,7 @@ describe("Response Mapper Tests", () => {
           statusCode: "0004",
           issueDate: "20250204000000",
           prescriptionTreatmentType: TreatmentType.ACUTE,
-          prescriptionPendingCancellation: false,
-          itemsPendingCancellation: false,
+          pendingCancellation: false,
           nhsNumber: "9999999111",
           given: ["Fall"],
           family: "Back"
@@ -164,8 +160,7 @@ describe("Response Mapper Tests", () => {
           statusCode: "0000",
           issueDate: "20250204000000",
           prescriptionTreatmentType: TreatmentType.ACUTE,
-          prescriptionPendingCancellation: false,
-          itemsPendingCancellation: false,
+          pendingCancellation: false,
           nhsNumber: "9999999111",
           given: ["Fall"],
           family: "Back"
@@ -193,8 +188,7 @@ describe("Response Mapper Tests", () => {
           statusCode: "0001",
           issueDate: "20250204000000",
           prescriptionTreatmentType: TreatmentType.ACUTE,
-          prescriptionPendingCancellation: false,
-          itemsPendingCancellation: false,
+          pendingCancellation: false,
           nhsNumber: "9999999111",
           given: ["Fall"],
           family: "Back"
@@ -205,8 +199,7 @@ describe("Response Mapper Tests", () => {
           statusCode: "0000",
           issueDate: "20250204000000",
           prescriptionTreatmentType: TreatmentType.ACUTE,
-          prescriptionPendingCancellation: false,
-          itemsPendingCancellation: false,
+          pendingCancellation: false,
           nhsNumber: "9999999111",
           given: ["Fall"],
           family: "Back"
@@ -217,8 +210,7 @@ describe("Response Mapper Tests", () => {
           statusCode: "0004",
           issueDate: "20250204000000",
           prescriptionTreatmentType: TreatmentType.ACUTE,
-          prescriptionPendingCancellation: false,
-          itemsPendingCancellation: false,
+          pendingCancellation: false,
           nhsNumber: "9999999111",
           given: ["Fall"],
           family: "Back"
@@ -368,8 +360,7 @@ describe("Response Mapper Tests", () => {
           issueNumber: 1,
           maxRepeats: 7,
           prescriptionTreatmentType: TreatmentType.ERD,
-          prescriptionPendingCancellation: false,
-          itemsPendingCancellation: false,
+          pendingCancellation: false,
           nhsNumber: "9732730684",
           given: ["ETTA"],
           family: "CORY",
@@ -382,8 +373,482 @@ describe("Response Mapper Tests", () => {
           statusCode: "0006",
           issueDate: "20250204000000",
           prescriptionTreatmentType: TreatmentType.ACUTE,
-          prescriptionPendingCancellation: false,
-          itemsPendingCancellation: false,
+          pendingCancellation: false,
+          nhsNumber: "9732730684",
+          given: ["ETTA"],
+          family: "CORY",
+          prefix: ["MISS"],
+          suffix: ["OBE"]
+        }
+      ])
+    })
+
+    // new combined extension
+    it("should correctly set the pending cancellation flag", () => {
+      const mockBundle: Bundle = {
+        resourceType: "Bundle",
+        type: "searchset",
+        entry: [
+          {
+            fullUrl: "urn:uuid:PATIENT-123-567-890",
+            search: {
+              mode: "include"
+            },
+            resource: {
+              resourceType: "Patient",
+              identifier: [{
+                system: "https://fhir.nhs.uk/Id/nhs-number",
+                value: "9732730684"
+              }],
+              name: [{
+                prefix: ["MISS"],
+                suffix: ["OBE"],
+                given: ["ETTA"],
+                family: "CORY"
+              }]
+            }
+          },
+          {
+            fullUrl: "urn:uuid:PRESCRIPTION-111-111-111",
+            search: {
+              mode: "match"
+            },
+            resource: {
+              resourceType: "RequestGroup",
+              identifier: [{
+                system: "https://fhir.nhs.uk/Id/prescription-order-number",
+                value: "335C70-A83008-111111"
+              }],
+              subject: {
+                reference: "urn:uuid:PATIENT-123-567-890"
+              },
+              status: "active",
+              intent: "reflex-order",
+              authoredOn: "20250204000000",
+              extension: [
+                {
+                  url: "https://fhir.nhs.uk/StructureDefinition/Extension-EPS-PrescriptionStatusHistory", //old
+                  extension: [{
+                    url: "status",
+                    valueCoding : {
+                      system: "https://fhir.nhs.uk/CodeSystem/EPS-task-business-status",
+                      code: "0001",
+                      display: "To be Dispensed"
+                    }
+                  }]
+                },
+                {
+                  url: "https://fhir.nhs.uk/StructureDefinition/Extension-EPS-RepeatInformation",
+                  extension: [
+                    {
+                      url: "numberOfRepeatsIssued",
+                      valueInteger: 1
+                    },
+                    {
+                      url: "numberOfRepeatsAllowed",
+                      valueInteger: 7
+                    }
+                  ]
+                },
+                {
+                  url: "https://fhir.nhs.uk/StructureDefinition/Extension-PendingCancellation",
+                  valueBoolean: true
+                }
+              ]
+            }
+          },
+          {
+            fullUrl: "urn:uuid:PRESCRIPTION-222-222-222",
+            search: {
+              mode: "match"
+            },
+            resource: {
+              resourceType: "RequestGroup",
+              identifier: [{
+                system: "https://fhir.nhs.uk/Id/prescription-order-number",
+                value: "335C70-A83008-222222"
+              }],
+              subject: {
+                reference: "urn:uuid:PATIENT-123-567-890"
+              },
+              status: "active",
+              intent: "order",
+              authoredOn: "20250204000000",
+              extension: [
+                {
+                  url: "https://fhir.nhs.uk/StructureDefinition/Extension-DM-PrescriptionStatusHistory",
+                  extension: [{
+                    url: "status",
+                    valueCoding : {
+                      system: "https://fhir.nhs.uk/CodeSystem/EPS-task-business-status",
+                      code: "0006",
+                      display: "Dispensed"
+                    }
+                  }]
+                },
+                {
+                  url: "https://fhir.nhs.uk/StructureDefinition/Extension-PendingCancellation",
+                  valueBoolean: false
+                }
+              ]
+            }
+          }
+        ]
+      }
+
+      const result = mapResponseToPrescriptionSummary(mockBundle)
+
+      expect(result).toEqual([
+        {
+          prescriptionId: "335C70-A83008-111111",
+          isDeleted: false,
+          statusCode: "0001",
+          issueDate: "20250204000000",
+          issueNumber: 1,
+          maxRepeats: 7,
+          prescriptionTreatmentType: TreatmentType.ERD,
+          pendingCancellation: true,
+          nhsNumber: "9732730684",
+          given: ["ETTA"],
+          family: "CORY",
+          prefix: ["MISS"],
+          suffix: ["OBE"]
+        },
+        {
+          prescriptionId: "335C70-A83008-222222",
+          isDeleted: false,
+          statusCode: "0006",
+          issueDate: "20250204000000",
+          prescriptionTreatmentType: TreatmentType.ACUTE,
+          pendingCancellation: false,
+          nhsNumber: "9732730684",
+          given: ["ETTA"],
+          family: "CORY",
+          prefix: ["MISS"],
+          suffix: ["OBE"]
+        }
+      ])
+    })
+
+    // old separate extension
+    // eslint-disable-next-line max-len
+    it("should correctly set the pending cancellation flag when there is a prescription level pending cancellation", () => {
+      const mockBundle: Bundle = {
+        resourceType: "Bundle",
+        type: "searchset",
+        entry: [
+          {
+            fullUrl: "urn:uuid:PATIENT-123-567-890",
+            search: {
+              mode: "include"
+            },
+            resource: {
+              resourceType: "Patient",
+              identifier: [{
+                system: "https://fhir.nhs.uk/Id/nhs-number",
+                value: "9732730684"
+              }],
+              name: [{
+                prefix: ["MISS"],
+                suffix: ["OBE"],
+                given: ["ETTA"],
+                family: "CORY"
+              }]
+            }
+          },
+          {
+            fullUrl: "urn:uuid:PRESCRIPTION-111-111-111",
+            search: {
+              mode: "match"
+            },
+            resource: {
+              resourceType: "RequestGroup",
+              identifier: [{
+                system: "https://fhir.nhs.uk/Id/prescription-order-number",
+                value: "335C70-A83008-111111"
+              }],
+              subject: {
+                reference: "urn:uuid:PATIENT-123-567-890"
+              },
+              status: "active",
+              intent: "reflex-order",
+              authoredOn: "20250204000000",
+              extension: [
+                {
+                  url: "https://fhir.nhs.uk/StructureDefinition/Extension-EPS-PrescriptionStatusHistory", //old
+                  extension: [{
+                    url: "status",
+                    valueCoding : {
+                      system: "https://fhir.nhs.uk/CodeSystem/EPS-task-business-status",
+                      code: "0001",
+                      display: "To be Dispensed"
+                    }
+                  }]
+                },
+                {
+                  url: "https://fhir.nhs.uk/StructureDefinition/Extension-EPS-RepeatInformation",
+                  extension: [
+                    {
+                      url: "numberOfRepeatsIssued",
+                      valueInteger: 1
+                    },
+                    {
+                      url: "numberOfRepeatsAllowed",
+                      valueInteger: 7
+                    }
+                  ]
+                },
+                {
+                  url: "https://fhir.nhs.uk/StructureDefinition/Extension-PendingCancellation",
+                  extension: [
+                    {
+                      url: "prescriptionPendingCancellation",
+                      valueBoolean: true
+                    },
+                    {
+                      url: "lineItemPendingCancellation",
+                      valueBoolean: false
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            fullUrl: "urn:uuid:PRESCRIPTION-222-222-222",
+            search: {
+              mode: "match"
+            },
+            resource: {
+              resourceType: "RequestGroup",
+              identifier: [{
+                system: "https://fhir.nhs.uk/Id/prescription-order-number",
+                value: "335C70-A83008-222222"
+              }],
+              subject: {
+                reference: "urn:uuid:PATIENT-123-567-890"
+              },
+              status: "active",
+              intent: "order",
+              authoredOn: "20250204000000",
+              extension: [
+                {
+                  url: "https://fhir.nhs.uk/StructureDefinition/Extension-DM-PrescriptionStatusHistory",
+                  extension: [{
+                    url: "status",
+                    valueCoding : {
+                      system: "https://fhir.nhs.uk/CodeSystem/EPS-task-business-status",
+                      code: "0006",
+                      display: "Dispensed"
+                    }
+                  }]
+                },
+                {
+                  url: "https://fhir.nhs.uk/StructureDefinition/Extension-PendingCancellation",
+                  extension: [
+                    {
+                      url: "prescriptionPendingCancellation",
+                      valueBoolean: false
+                    },
+                    {
+                      url: "lineItemPendingCancellation",
+                      valueBoolean: false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      }
+      const result = mapResponseToPrescriptionSummary(mockBundle)
+
+      expect(result).toEqual([
+        {
+          prescriptionId: "335C70-A83008-111111",
+          isDeleted: false,
+          statusCode: "0001",
+          issueDate: "20250204000000",
+          issueNumber: 1,
+          maxRepeats: 7,
+          prescriptionTreatmentType: TreatmentType.ERD,
+          pendingCancellation: true,
+          nhsNumber: "9732730684",
+          given: ["ETTA"],
+          family: "CORY",
+          prefix: ["MISS"],
+          suffix: ["OBE"]
+        },
+        {
+          prescriptionId: "335C70-A83008-222222",
+          isDeleted: false,
+          statusCode: "0006",
+          issueDate: "20250204000000",
+          prescriptionTreatmentType: TreatmentType.ACUTE,
+          pendingCancellation: false,
+          nhsNumber: "9732730684",
+          given: ["ETTA"],
+          family: "CORY",
+          prefix: ["MISS"],
+          suffix: ["OBE"]
+        }
+      ])
+    })
+
+    it("should correctly set the pending cancellation flag when there is a item level pending cancellation", () => {
+      const mockBundle: Bundle = {
+        resourceType: "Bundle",
+        type: "searchset",
+        entry: [
+          {
+            fullUrl: "urn:uuid:PATIENT-123-567-890",
+            search: {
+              mode: "include"
+            },
+            resource: {
+              resourceType: "Patient",
+              identifier: [{
+                system: "https://fhir.nhs.uk/Id/nhs-number",
+                value: "9732730684"
+              }],
+              name: [{
+                prefix: ["MISS"],
+                suffix: ["OBE"],
+                given: ["ETTA"],
+                family: "CORY"
+              }]
+            }
+          },
+          {
+            fullUrl: "urn:uuid:PRESCRIPTION-111-111-111",
+            search: {
+              mode: "match"
+            },
+            resource: {
+              resourceType: "RequestGroup",
+              identifier: [{
+                system: "https://fhir.nhs.uk/Id/prescription-order-number",
+                value: "335C70-A83008-111111"
+              }],
+              subject: {
+                reference: "urn:uuid:PATIENT-123-567-890"
+              },
+              status: "active",
+              intent: "reflex-order",
+              authoredOn: "20250204000000",
+              extension: [
+                {
+                  url: "https://fhir.nhs.uk/StructureDefinition/Extension-EPS-PrescriptionStatusHistory", //old
+                  extension: [{
+                    url: "status",
+                    valueCoding : {
+                      system: "https://fhir.nhs.uk/CodeSystem/EPS-task-business-status",
+                      code: "0001",
+                      display: "To be Dispensed"
+                    }
+                  }]
+                },
+                {
+                  url: "https://fhir.nhs.uk/StructureDefinition/Extension-EPS-RepeatInformation",
+                  extension: [
+                    {
+                      url: "numberOfRepeatsIssued",
+                      valueInteger: 1
+                    },
+                    {
+                      url: "numberOfRepeatsAllowed",
+                      valueInteger: 7
+                    }
+                  ]
+                },
+                {
+                  url: "https://fhir.nhs.uk/StructureDefinition/Extension-PendingCancellation",
+                  extension: [
+                    {
+                      url: "prescriptionPendingCancellation",
+                      valueBoolean: false
+                    },
+                    {
+                      url: "lineItemPendingCancellation",
+                      valueBoolean: true
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            fullUrl: "urn:uuid:PRESCRIPTION-222-222-222",
+            search: {
+              mode: "match"
+            },
+            resource: {
+              resourceType: "RequestGroup",
+              identifier: [{
+                system: "https://fhir.nhs.uk/Id/prescription-order-number",
+                value: "335C70-A83008-222222"
+              }],
+              subject: {
+                reference: "urn:uuid:PATIENT-123-567-890"
+              },
+              status: "active",
+              intent: "order",
+              authoredOn: "20250204000000",
+              extension: [
+                {
+                  url: "https://fhir.nhs.uk/StructureDefinition/Extension-DM-PrescriptionStatusHistory",
+                  extension: [{
+                    url: "status",
+                    valueCoding : {
+                      system: "https://fhir.nhs.uk/CodeSystem/EPS-task-business-status",
+                      code: "0006",
+                      display: "Dispensed"
+                    }
+                  }]
+                },
+                {
+                  url: "https://fhir.nhs.uk/StructureDefinition/Extension-PendingCancellation",
+                  extension: [
+                    {
+                      url: "prescriptionPendingCancellation",
+                      valueBoolean: false
+                    },
+                    {
+                      url: "lineItemPendingCancellation",
+                      valueBoolean: false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      }
+      const result = mapResponseToPrescriptionSummary(mockBundle)
+
+      expect(result).toEqual([
+        {
+          prescriptionId: "335C70-A83008-111111",
+          isDeleted: false,
+          statusCode: "0001",
+          issueDate: "20250204000000",
+          issueNumber: 1,
+          maxRepeats: 7,
+          prescriptionTreatmentType: TreatmentType.ERD,
+          pendingCancellation: true,
+          nhsNumber: "9732730684",
+          given: ["ETTA"],
+          family: "CORY",
+          prefix: ["MISS"],
+          suffix: ["OBE"]
+        },
+        {
+          prescriptionId: "335C70-A83008-222222",
+          isDeleted: false,
+          statusCode: "0006",
+          issueDate: "20250204000000",
+          prescriptionTreatmentType: TreatmentType.ACUTE,
+          pendingCancellation: false,
           nhsNumber: "9732730684",
           given: ["ETTA"],
           family: "CORY",


### PR DESCRIPTION
## Summary
- Routine Change
- :warning: Potential issues that might be caused by this change

### Details
- Updates the UI backend to be able to handle both the current and new format of the pending cancellation FHIR extension
- Consolidates the `prescriptionPendingCancellation` and `itemsPendingCancellation` flags for prescription list into a single `pendingCancellation` flag to reflect that there will soon be no distinction in the API response and aligns with how its currently  displayed in the UI where there is already no distinction.